### PR TITLE
Make auto fill smarter.

### DIFF
--- a/website-guts/assets/js/global.js
+++ b/website-guts/assets/js/global.js
@@ -501,31 +501,49 @@ window.optly.mrkt.utils.smoothScroll = function(event) {
 w.optly_q.push([function(){
 	if(typeof w.optly.mrkt.user.acctData === 'object'){
 		if(
+				$('[name="first_name"]').val() === '' &&
 				typeof w.optly.mrkt.user.acctData.first_name === 'string' &&
 				w.optly.mrkt.user.acctData.first_name
+
 			){
 			$('[name="first_name"]').val(w.optly.mrkt.user.acctData.first_name);
 		}
 		if(
+				$('[name="last_name"]').val() === '' &&
 				typeof w.optly.mrkt.user.acctData.last_name === 'string' &&
 				w.optly.mrkt.user.acctData.last_name
+
 			){
 			$('[name="last_name"]').val(w.optly.mrkt.user.acctData.last_name);
 		}
-		if(
-				typeof w.optly.mrkt.user.acctData.first_name === 'string' &&
-				w.optly.mrkt.user.acctData.first_name &&
-				typeof w.optly.mrkt.user.acctData.last_name === 'string' &&
-				w.optly.mrkt.user.acctData.last_name
-			){
-				$('[name="name"]').val(w.optly.mrkt.user.acctData.first_name + ' ' + w.optly.mrkt.user.acctData.last_name);
+		if($('[name="name"]').val() === ''){
+			if(
+					typeof w.optly.mrkt.user.acctData.first_name === 'string' &&
+					w.optly.mrkt.user.acctData.first_name
+				){
+				$('[name="name"]').val(w.optly.mrkt.user.acctData.first_name);
+			}
+			if(
+					typeof w.optly.mrkt.user.acctData.last_name === 'string' &&
+					w.optly.mrkt.user.acctData.last_name
+				){
+				if( $('[name="name"]').val() ){
+					$('[name="name"]').val($('[name="name"]').val() + ' ' + w.optly.mrkt.user.acctData.last_name);
+				} else {
+					$('[name="name"]').val(w.optly.mrkt.user.acctData.last_name);
+				}
+			}
 		}
 		if(
 				typeof w.optly.mrkt.user.acctData.email === 'string' &&
 				w.optly.mrkt.user.acctData.email
 			){
-			$('[name="email"]').val(w.optly.mrkt.user.acctData.email);
-			$('[name="email_address"]').val(w.optly.mrkt.user.acctData.email);
+				if($('[name="email"]').val() === ''){
+					$('[name="email"]').val(w.optly.mrkt.user.acctData.email);
+				}
+				if($('[name="email_address"]').val() === ''){
+					$('[name="email_address"]').val(w.optly.mrkt.user.acctData.email);
+				}
 		}
 	}
 }]);

--- a/website-guts/assets/js/global.js
+++ b/website-guts/assets/js/global.js
@@ -500,19 +500,30 @@ window.optly.mrkt.utils.smoothScroll = function(event) {
 //pre-populate fields from account info
 w.optly_q.push([function(){
 	if(typeof w.optly.mrkt.user.acctData === 'object'){
-		if(typeof w.optly.mrkt.user.acctData.first_name === 'string'){
+		if(
+				typeof w.optly.mrkt.user.acctData.first_name === 'string' &&
+				w.optly.mrkt.user.acctData.first_name
+			){
 			$('[name="first_name"]').val(w.optly.mrkt.user.acctData.first_name);
 		}
-		if(typeof w.optly.mrkt.user.acctData.last_name === 'string'){
+		if(
+				typeof w.optly.mrkt.user.acctData.last_name === 'string' &&
+				w.optly.mrkt.user.acctData.last_name
+			){
 			$('[name="last_name"]').val(w.optly.mrkt.user.acctData.last_name);
 		}
 		if(
 				typeof w.optly.mrkt.user.acctData.first_name === 'string' &&
-				typeof w.optly.mrkt.user.acctData.last_name === 'string'
+				w.optly.mrkt.user.acctData.first_name &&
+				typeof w.optly.mrkt.user.acctData.last_name === 'string' &&
+				w.optly.mrkt.user.acctData.last_name
 			){
 				$('[name="name"]').val(w.optly.mrkt.user.acctData.first_name + ' ' + w.optly.mrkt.user.acctData.last_name);
 		}
-		if(typeof w.optly.mrkt.user.acctData.email === 'string'){
+		if(
+				typeof w.optly.mrkt.user.acctData.email === 'string' &&
+				w.optly.mrkt.user.acctData.email
+			){
 			$('[name="email"]').val(w.optly.mrkt.user.acctData.email);
 			$('[name="email_address"]').val(w.optly.mrkt.user.acctData.email);
 		}


### PR DESCRIPTION
**Two changes**:

1. Doesn't overwrite values in fields if the fields already have values

2. If `last_name` is falsy, but `first_name` is truthy, the name field will get only `first_name` as the value and vice versa. If both are truthy, the field will get a value of both first name and last name.

**To test**:

Change the `first_name` and `last_name` peroperty values in the `website-guts/endpoint-mocks/accountInfo.json` static JSON file. Restart your server. Verify that the correct values exist on any lead form.

To ensure that the values don't get overwritten, change line 137 of `grunt/connect.js` to: 

```js
setTimeout(function(){
  res.end( grunt.file.read(paths[randIndex]) );
}, 5000);
```

This adds a 5 second delay to the response on the /account/info endpoint. Restart your server. Visit /free-trial and then enter values into the form fields quickly. Verify that the values were not overwritten when the response to /account/info were received.