### PR TITLE
revert aseetsDir path for file reving in grunt/config

### DIFF
--- a/grunt/config.js
+++ b/grunt/config.js
@@ -22,7 +22,7 @@ var config = {
       variables: {
         environment: 'production',
         environmentData: 'website-guts/data/environments/production/environmentVariables.json',
-        assetsDir: '//du7782fucwe1l.cloudfront.net',
+        assetsDir: '/dist/assets',
         link_path: '',
         sassImagePath: '/img',
         compress_js: true,


### PR DESCRIPTION
@kylerush @stewsmith This PR reverts https://github.com/optimizely/marketing-website/pull/771 that was in response to https://github.com/optimizely/marketing-website/pull/770 which resulted in an outage to the marketing website.  

PR can be tested by running grunt build and in `dist/assets/css/` comparing the stylesheet hash to that in any index.html in `dist`

![screen shot 2015-01-07 at 12 04 32 pm](https://cloud.githubusercontent.com/assets/4656726/5649835/2099f13e-9667-11e4-9d66-dd49aee2f87c.png)
