### PR TITLE
created mobile opt out

### DIFF
--- a/website/opt-out-mo/index.hbs
+++ b/website/opt-out-mo/index.hbs
@@ -1,0 +1,22 @@
+---
+layout: simple.hbs
+seo_title: "Opt out of Optimizely Onboarding"
+page_header: false
+body_class:
+- mobile-opt-out
+compact_header: true
+---
+  <div class="container">
+    <div class="row">
+      <div class="columns twelve">
+        <h1>You have successfully opted out of Optimizely for iOS Onboarding</h1>
+        <p>Other resources you may be interested in:</p>
+          <ul>
+            <li>Optiverse</li>
+            <li>Knowledge Base</li>
+          </ul>
+            
+        
+      </div>
+    </div><!--/.row-->
+  </div>

--- a/website/opt-out-mo/index.hbs
+++ b/website/opt-out-mo/index.hbs
@@ -9,13 +9,13 @@ compact_header: true
   <div class="container">
     <div class="row">
       <div class="columns twelve">
-        <h1>You have successfully opted out of Optimizely for iOS Onboarding</h1>
+        <h1><center>You have successfully opted out of Optimizely for iOS Onboarding</center></h1>
         <p>Other resources you may be interested in:</p>
           <ul>
             <li>Optiverse</li>
             <li>Knowledge Base</li>
           </ul>
-            
+          <p>&nbsp;</p>
         
       </div>
     </div><!--/.row-->


### PR DESCRIPTION
for members of our mobile onboarding, we'd like to create an easy way for them to opt out of our onboarding without navigating our subscription center. By visiting this page they will stop receiving mobile onboarding emails, while still remain subscribed to other email subscriptions.