### PR TITLE
Change image src for segment

### DIFF
--- a/website/partners/technology/segment/index.hbs
+++ b/website/partners/technology/segment/index.hbs
@@ -4,7 +4,7 @@ title: "Segment"
 integrations: true
 priority: 48
 summary: "Pass your data from Optimizely to 122+ other tools with a single integration."
-logo: "//d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/partner-logos/segment-logo-black.svg"
+logo: "//d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/partner-logos/technology/segment.png"
 website_link: "https://segment.com/"
 website_display: "www.segment.com"
 kb_article: "https://help.optimizely.com/hc/en-us/articles/200039775#segment"


### PR DESCRIPTION
The segment logo on the /partners/technology page is currently broken. This PR fixes that.