### PR TITLE
MKT-953 -- Add stats engine to navs, update stats metadata

### DIFF
--- a/website-guts/templates/layouts/wrapper.hbs
+++ b/website-guts/templates/layouts/wrapper.hbs
@@ -91,6 +91,7 @@ layout_modals:
                                             <li class="first"><a href="{{linkPath}}/benefits/">Benefits</a></li>
                                             <li><a href="{{linkPath}}/pricing">Plans and Pricing</a></li>
                                             <li><a href="{{linkPath}}/mobile/">Mobile</a></li>
+                                            <li><a href="{{linkPath}}/statistics/">Stats Engine</a></li>
                                             <li><a href="{{linkPath}}/customers/">Customer List</a></li>
                                             <li><a href="{{linkPath}}/customers/customer-stories/">Customer Stories</a></li>
                                             <li class="last"><a href="{{linkPath}}/resources/live-demo-webinar/">Live Demo Signup</a></li>
@@ -155,6 +156,7 @@ layout_modals:
                                                 <li><a href="{{linkPath}}/pricing">Plans and Pricing</a></li>
                                                 <li><a href="{{linkPath}}/benefits/">Benefits</a></li>
                                                 <li><a href="{{linkPath}}/mobile/">iOS</a></li>
+                                                <li><a href="{{linkPath}}/statistics/">Stats Engine</a></li>
                                                 <li><a href="{{linkPath}}/partners/">Optimizely for Agencies</a></li>
                                                 <li><a href="http://developers.optimizely.com">Optimizely for Developers</a></li>
                                                 <li><a href="{{linkPath}}/ecommerce/">Optimizely for E-commerce</a></li>

--- a/website/android/index.hbs
+++ b/website/android/index.hbs
@@ -6,10 +6,8 @@ page_script:
 body_class:
 - android-page
 footer_style: grey
-og_title:
-- "Make your Android app more engaging"
-og_description:
-- "Learn how to optimize your app for acquisition, engagement and retention."
+og_title: "Make your Android app more engaging"
+og_description: "Learn how to optimize your app for acquisition, engagement and retention."
 ---
 {{#with android_data}}
 <div class="page-bg android bg-img" style="background-image: url('{{main_bg_img}}')">

--- a/website/mobile/index.hbs
+++ b/website/mobile/index.hbs
@@ -8,10 +8,8 @@ body_class:
 - mobile-page
 page_script: mobile.js
 footer_style: grey
-og_title:
-- "Make your app more engaging"
-og_description:
-- "Learn how to optimize your app for acquisition, engagement and retention."
+og_title: "Make your app more engaging"
+og_description: "Learn how to optimize your app for acquisition, engagement and retention."
 ---
 <section id="hero" class="panel bg-img" style="background-image: url('{{mobile_page_mvpp_data.hero.bg_img}}')">
   {{#with mobile_page_mvpp_data.hero}}

--- a/website/pricing/index.hbs
+++ b/website/pricing/index.hbs
@@ -12,10 +12,8 @@ modals:
 - downgrade_plan_confirm_compiled
 - pricing_plan_signup_thank_you_compiled
 seo_title: Pricing
-og_title:
-- "Plans and Pricing"
-og_description:
-- "Get started optimizing instantly, or build a custom plan for your business."
+og_title: "Plans and Pricing"
+og_description: "Get started optimizing instantly, or build a custom plan for your business."
 ---
 <section class="blue-bg" id="plan-section">
   <div class="container">

--- a/website/statistics/index.hbs
+++ b/website/statistics/index.hbs
@@ -1,6 +1,5 @@
 ---
 layout: statistics.hbs
-seo_title: "Statistics Engine"
 compact_header: false
 modals:
 - video_modal_compiled

--- a/website/statistics/index.hbs
+++ b/website/statistics/index.hbs
@@ -8,8 +8,11 @@ body_class:
 - statistics-page
 page_script: statistics.js
 footer_style: grey
-og_title: ""
-og_description: ""
+seo_title: "Optimizely Stats Engine"
+og_title:
+- "Optimizely Stats Engine"
+og_description:
+- "Statistics for the Internet age is here."
 ---
 <style>
 

--- a/website/statistics/index.hbs
+++ b/website/statistics/index.hbs
@@ -8,10 +8,8 @@ body_class:
 page_script: statistics.js
 footer_style: grey
 seo_title: "Optimizely Stats Engine"
-og_title:
-- "Optimizely Stats Engine"
-og_description:
-- "Statistics for the Internet age is here."
+og_title: "Optimizely Stats Engine"
+og_description: "Statistics for the Internet age is here."
 ---
 <style>
 


### PR DESCRIPTION
[MKT-953](https://optimizely.atlassian.net/browse/MKT-953)

* Add link to /statistics page to the Products dropdown menu as: "Stats Engine"
* Add link to /statistics to the site footer, under Product features and benefits menu as: "Stats Engine"
* Update meta info on page:
- seo_title: "Optimizely Stats Engine" 
- og_title: "Optimizely Stats Engine" 
- og_description: "Statistics for the Internet age is here."