### PR TITLE
Rpam/stats copy cleanup

### DIFF
--- a/website-guts/assets/css/pages/statistics.scss
+++ b/website-guts/assets/css/pages/statistics.scss
@@ -272,6 +272,12 @@ body.statistics-page {
         color: $blue;
         font-size: 80px;
         font-weight: 400;
+        span {
+          font-size: 0.8em;
+          position: relative;
+          top: -5px;
+          left: -7px;
+        }
       }
     }
 

--- a/website/statistics/index.hbs
+++ b/website/statistics/index.hbs
@@ -1,6 +1,6 @@
 ---
 layout: statistics.hbs
-seo_title: Statistics Engine
+seo_title: "Statistics Engine"
 compact_header: false
 modals:
 - video_modal_compiled
@@ -8,14 +8,10 @@ body_class:
 - statistics-page
 page_script: statistics.js
 footer_style: grey
-og_title:
-- ""
-og_description:
-- ""
+og_title ""
+og_description: ""
 ---
-<style>
 
-</style>
 <section id="hero" class="panel bg-img" style="background-image: url('{{statistics_data.hero.bg_img}}')">
   {{#with statistics_data.hero}}
   <div id="signup-form-panel-top">

--- a/website/statistics/statistics_data.yml
+++ b/website/statistics/statistics_data.yml
@@ -63,7 +63,7 @@ worry:
     text: "No need to commit to a sample size or duration in advance. You can also see conclusive results up to twice as fast."
   -
     title: "Leave the<br>Stats to Us"
-    text: "No need to change how you run your tests. Stats engine works exactly the way you expect it to, without any extra work."
+    text: "No need to change how you run your tests. Stats Engine works exactly the way you expect it to, without any extra work."
   cta_title: "Get answers to your FAQs"
   cta_text: "Check out Optiverse"
   cta_link: "https://community.optimizely.com/t5/Product-What-s-New/Product-Update-A-new-Stats-Engine-to-power-your-results/ba-p/8518"

--- a/website/statistics/statistics_data.yml
+++ b/website/statistics/statistics_data.yml
@@ -1,7 +1,7 @@
 hero:
   bg_img: "//d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/statistics/hero.jpg"
   title: "Goodbye traditional statistics"
-  subtitle: "Statistics for the internet age is here"
+  subtitle: "Statistics for the Internet age is here"
   link_anchor_text: "Learn More"
 lets_talk:
   title: "LET'S TALK STATS"
@@ -48,8 +48,8 @@ compare:
     pre: "setting a 95% significance<br>level can result in a"
     percentage: "30%"
     post: "or more chance you'll make the wrong decision if you don't avoid pitfalls*"
-  footnote: "* We simulated millions of A/A tests under both frameworks and calculated error rate by determining the percentage of experiments that declared a winning or losing variation given a continous monitoring policy. (1000+ visitors)"
-  cta_title: "Interested in how stats engine affects your results?"
+  footnote: "* We simulated millions of A/A tests under both frameworks and calculated error rate by determining the percentage of experiments that declared a winning or losing variation given a continuous monitoring policy. (1000+ visitors)"
+  cta_title: "Interested in how Stats Engine affects your results?"
   cta_text: "Learn more"
   cta_link: "http://blog.optimizely.com/2015/01/20/statistics-for-the-internet-age-the-story-behind-optimizelys-new-stats-engine/"
 worry:

--- a/website/statistics/statistics_data.yml
+++ b/website/statistics/statistics_data.yml
@@ -47,7 +47,7 @@ compare:
     title: "With traditional statistics"
     pre: "setting a 95% significance<br>level results in a"
     percentage: "<span><</span>70%"
-    post: "you'll make the right decision if you don't avoid pitfalls*"
+    post: "chance you'll make the right decision if you don't avoid pitfalls*"
   footnote: "* We simulated millions of A/A tests under both frameworks and calculated error rate by determining the percentage of experiments that declared a winning or losing variation given a continuous monitoring policy. (1000+ visitors)"
   cta_title: "Interested in how Stats Engine affects your results?"
   cta_text: "Learn more"

--- a/website/statistics/statistics_data.yml
+++ b/website/statistics/statistics_data.yml
@@ -46,7 +46,7 @@ compare:
     id: 2
     title: "With traditional statistics"
     pre: "setting a 95% significance<br>level results in a"
-    percentage: "<70%"
+    percentage: "<span><</span>70%"
     post: "you'll make the right decision if you don't avoid pitfalls*"
   footnote: "* We simulated millions of A/A tests under both frameworks and calculated error rate by determining the percentage of experiments that declared a winning or losing variation given a continuous monitoring policy. (1000+ visitors)"
   cta_title: "Interested in how Stats Engine affects your results?"


### PR DESCRIPTION
Made a lot of changes:

- Capitalized Internet in Hero area
- Capitalized Stats Engine in "Interested in how Stats Engine affects your results" in error graphic section
- Capitalized Engine in "Leave the stats to us" section at the bottom of the page
- Fixed typo in footnote (continous --> continuous)

Need to coordinate changes with @KarenLoughrey for translation purposes. Should not  be pushed live before translation occurs