### PR TITLE
broken request for Google Calendar endpoint on events page

### DIFF
--- a/grunt/concat.js
+++ b/grunt/concat.js
@@ -1,60 +1,71 @@
-module.exports = {
-  namespacePages: {
-    options: {
-      banner: '<%= grunt.config.get("concat_banner") %>',
-      footer: '<%= grunt.config.get("concat_footer") %>'
+var secondLastSlash = function(path) {
+  var split = path.split('/');
+
+  return split.splice(split.length - 2).join('/');
+};
+module.exports = function(grunt, options){
+  return {
+    namespacePages: {
+      options: {
+        banner: '<%= grunt.config.get("concat_banner") %>',
+        footer: '<%= grunt.config.get("concat_footer") %>',
+        process: function(src, filepath) {
+          return 'var targetName = "' + grunt.task.current.target + '" + "--" +  "' + secondLastSlash(filepath) + '";\n\n' + src;
+        }
+      },
+      src: ['pages/*.js', 'layouts/*.js'],
+      expand: true,
+      cwd: '<%= config.guts %>/assets/js/',
+      dest: '<%= config.dist %>/assets/js/'
     },
-    src: ['pages/*.js', 'layouts/*.js'],
-    expand: true,
-    cwd: '<%= config.guts %>/assets/js/',
-    dest: '<%= config.dist %>/assets/js/'
-  },
-  jqueryModernizr: {
-    src: [
-      '<%= config.guts %>/assets/js/libraries/jquery-2.1.1.min.js',
-      '<%= config.temp %>/assets/js/libraries/modernizr.2.8.3.min.js'
-    ],
-    expand: false,
-    flatten: true,
-    isFile: true,
-    dest: '<%= config.dist %>/assets/js/libraries/jquery-modernizr.min.js'
-  },
-  namespaceGlobal: {
-    options: {
-      banner: '<%= grunt.config.get("concat_banner") %>',
-      footer: '<%= grunt.config.get("concat_footer") %>'
+    jqueryModernizr: {
+      src: [
+        '<%= config.guts %>/assets/js/libraries/jquery-2.1.1.min.js',
+        '<%= config.temp %>/assets/js/libraries/modernizr.2.8.3.min.js'
+      ],
+      expand: false,
+      flatten: true,
+      isFile: true,
+      dest: '<%= config.dist %>/assets/js/libraries/jquery-modernizr.min.js'
     },
-    files: {
-        '<%= config.temp %>/assets/js/global.js': [
-          '<%= config.guts %>/assets/js/utils/oform_globals.js',
-          '<%= config.guts %>/assets/js/utils/check_complex_password.js',
-          '<%= config.guts %>/assets/js/utils/equal_height_grid.js',
-          '<%= config.guts %>/assets/js/utils/get_url_parameter.js',
-          '<%= config.guts %>/assets/js/utils/uri.js',
-          '<%= config.guts %>/assets/js/utils/guid_sprintf.js',
-          '<%= config.guts %>/assets/js/utils/form_helper_factory.js',
-          '<%= config.guts %>/assets/js/utils/form_helpers/*.js',
-          '<%= config.guts %>/assets/js/utils/trim_url.js',
-          '<%= config.guts %>/assets/js/global.js',
-          '<%= config.guts %>/assets/js/components/*.js',
-          '<%= config.guts %>/assets/js/services/*.js',
-          '!<%= config.guts %>/assets/js/services/user_state.js'
-          ]
-    }
-  },
-  concatBundle: {
-    files: {
-      '<%= config.dist %>/assets/js/bundle.js': [
-        '<%= config.bowerDir %>/jquery-cookie/jquery.cookie.js',
-        '<%= config.bowerDir %>/history.js/scripts/bundled-uncompressed/html4+html5/jquery.history.js',
-        '<%= config.guts %>/assets/js/libraries/handlebars-v1.3.0.js',
-        '<%= config.bowerDir %>/momentjs/moment.js',
-        '<%= config.temp %>/assets/js/handlebarsTemplates.js',
-        '<%= config.bowerDir %>/oform/dist/oForm.min.js',
-        '<%= config.temp %>/assets/js/global.js',
-        '<%= config.guts %>/assets/js/components/oForm-globals.js',
-        '<%= config.bowerDir %>/fitvids/jquery.fitvids.js'
-      ]
+    namespaceGlobal: {
+      options: {
+        banner: '<%= grunt.config.get("concat_banner") %>',
+        footer: '<%= grunt.config.get("concat_footer") %>'
+      },
+      files: {
+          '<%= config.temp %>/assets/js/global.js': [
+            '<%= config.guts %>/assets/js/utils/oform_globals.js',
+            '<%= config.guts %>/assets/js/utils/check_complex_password.js',
+            '<%= config.guts %>/assets/js/utils/equal_height_grid.js',
+            '<%= config.guts %>/assets/js/utils/get_url_parameter.js',
+            '<%= config.guts %>/assets/js/utils/uri.js',
+            '<%= config.guts %>/assets/js/utils/guid_sprintf.js',
+            '<%= config.guts %>/assets/js/utils/form_helper_factory.js',
+            '<%= config.guts %>/assets/js/utils/form_helpers/*.js',
+            '<%= config.guts %>/assets/js/utils/trim_url.js',
+            '<%= config.guts %>/assets/js/utils/stringify_error.js',
+            '<%= config.guts %>/assets/js/global.js',
+            '<%= config.guts %>/assets/js/components/*.js',
+            '<%= config.guts %>/assets/js/services/*.js',
+            '!<%= config.guts %>/assets/js/services/user_state.js'
+            ]
+      }
+    },
+    concatBundle: {
+      files: {
+        '<%= config.dist %>/assets/js/bundle.js': [
+          '<%= config.bowerDir %>/jquery-cookie/jquery.cookie.js',
+          '<%= config.bowerDir %>/history.js/scripts/bundled-uncompressed/html4+html5/jquery.history.js',
+          '<%= config.guts %>/assets/js/libraries/handlebars-v1.3.0.js',
+          '<%= config.bowerDir %>/momentjs/moment.js',
+          '<%= config.temp %>/assets/js/handlebarsTemplates.js',
+          '<%= config.bowerDir %>/oform/dist/oForm.min.js',
+          '<%= config.temp %>/assets/js/global.js',
+          '<%= config.guts %>/assets/js/components/oForm-globals.js',
+          '<%= config.bowerDir %>/fitvids/jquery.fitvids.js'
+        ]
+      }
     }
   }
 };

--- a/website-guts/assets/css/pages/events.scss
+++ b/website-guts/assets/css/pages/events.scss
@@ -6,6 +6,22 @@ body.events-page{
   .hide-events-link {
     display: none;
   }
+  .hide-past {
+    .past {
+      display: none;
+    }
+    .upcoming {
+      display: inline;
+    }
+  }
+  .hide-upcoming {
+    .past {
+      display: inline;
+    }
+    .upcoming {
+      display: none;
+    }
+  }
   .event-cont {
     border-bottom: 1px solid #444;
     padding-bottom: 30px;

--- a/website-guts/assets/css/pages/events.scss
+++ b/website-guts/assets/css/pages/events.scss
@@ -3,6 +3,9 @@ body.events-page{
     list-style-type: none;
     margin-bottom: 8px;
   }
+  .hide-events-link {
+    display: none;
+  }
   .event-cont {
     border-bottom: 1px solid #444;
     padding-bottom: 30px;
@@ -44,12 +47,16 @@ body.events-page{
         text-align: left;
       }
     }
-    .show-past-events {
+    .show-past-events,
+    .show-future-events {
       background: image-url('past-events.png') no-repeat left center;
       margin-left: 10px;
       padding-left: 63px;
       padding-top: 7px;
       width: 300px;
+      a {
+        display: block;
+      }
     }
   }
 }

--- a/website-guts/assets/js/pages/events.js
+++ b/website-guts/assets/js/pages/events.js
@@ -9,8 +9,7 @@ window.optly.mrkt.events.showEvents = function(resp, div){
   var htmlDecode,
     currentDateTime = new Date(),
     futureEvents = [],
-    pastEvents = [],
-    templateContext = {};
+    pastEvents = [];
 
   htmlDecode = function(text) {
     var urlRegex = /(https?:\/\/[^\s]+)/g;

--- a/website-guts/assets/js/pages/events.js
+++ b/website-guts/assets/js/pages/events.js
@@ -95,6 +95,13 @@ window.optly.mrkt.events.showEvents = function(resp, div){
         e.preventDefault();
         $('#get-future-events').parent().removeClass('hide-events-link');
         $(this).parent().addClass('hide-events-link');
+        $('#events-cont').find('h3').each(function(i, elm) {
+          if(i) {
+            $(elm).removeClass('hide-upcoming').addClass('hide-past');
+          } else {
+            $(elm).removeClass('hide-past').addClass('hide-upcoming');
+          }
+        });
         templateContext.events = pastEvents;
         $(div).html(window.optly.mrkt.templates.eventDisplay(templateContext));
       });
@@ -103,7 +110,13 @@ window.optly.mrkt.events.showEvents = function(resp, div){
         e.preventDefault();
         $('#get-past-events').parent().removeClass('hide-events-link');
         $(this).parent().addClass('hide-events-link');
-        templateContext.events = futureEvents;
+        $('#events-cont').find('h3').each(function(i, elm) {
+          if(i) {
+            $(elm).removeClass('hide-past').addClass('hide-upcoming');
+          } else {
+            $(elm).removeClass('hide-upcoming').addClass('hide-past');
+          }
+        });        templateContext.events = futureEvents;
         $(div).html(window.optly.mrkt.templates.eventDisplay(templateContext));
       });
 

--- a/website-guts/assets/js/pages/events.js
+++ b/website-guts/assets/js/pages/events.js
@@ -87,11 +87,9 @@ window.optly.mrkt.events.showEvents = function(resp, div){
         pastEvents.splice(0, pastEvents.length - 30);
       }
 
-      templateContext.events = futureEvents;
-
-      $(div).html(window.optly.mrkt.templates.eventDisplay(templateContext));
+      $(div).html(window.optly.mrkt.templates.eventDisplay({events: futureEvents}));
       
-      $('body').delegate('#get-past-events', 'click', function(e){
+      $('#get-past-events').on('click', function(e){
         e.preventDefault();
         $('#get-future-events').parent().removeClass('hide-events-link');
         $(this).parent().addClass('hide-events-link');
@@ -102,11 +100,10 @@ window.optly.mrkt.events.showEvents = function(resp, div){
             $(elm).removeClass('hide-past').addClass('hide-upcoming');
           }
         });
-        templateContext.events = pastEvents;
-        $(div).html(window.optly.mrkt.templates.eventDisplay(templateContext));
+        $(div).html(window.optly.mrkt.templates.eventDisplay({events: pastEvents}));
       });
       
-      $('body').delegate('#get-future-events', 'click', function(e){
+      $('#get-future-events').on('click', function(e){
         e.preventDefault();
         $('#get-past-events').parent().removeClass('hide-events-link');
         $(this).parent().addClass('hide-events-link');
@@ -116,8 +113,8 @@ window.optly.mrkt.events.showEvents = function(resp, div){
           } else {
             $(elm).removeClass('hide-upcoming').addClass('hide-past');
           }
-        });        templateContext.events = futureEvents;
-        $(div).html(window.optly.mrkt.templates.eventDisplay(templateContext));
+        });
+        $(div).html(window.optly.mrkt.templates.eventDisplay({events: futureEvents}));
       });
 
     } else {

--- a/website-guts/assets/js/pages/events.js
+++ b/website-guts/assets/js/pages/events.js
@@ -1,118 +1,118 @@
 window.optly.mrkt.events = {};
 
-window.optly.mrkt.events.showEvents = function(url, div){
+var gapi = window.gapi;
+var apiKey = 'AIzaSyDvPXqy9MlOTG39-J-MHR-OR2d2YgyJ9uE';
+var calendarId = 'optimizely.com_hh3e0hadjvjs9gh34mdlevverk@group.calendar.google.com';
 
-  var templateContext, htmlDecode;
+window.optly.mrkt.events.showEvents = function(resp, div){
 
-  templateContext = {};
-
-  templateContext.events = [];
+  var htmlDecode,
+    currentDateTime = new Date(),
+    futureEvents = [],
+    pastEvents = [],
+    templateContext = {};
 
   htmlDecode = function(text) {
     var urlRegex = /(https?:\/\/[^\s]+)/g;
     return text.replace(urlRegex, function(url) {
-        return '<a href="' + url + '">' + url + '</a>';
+      return '<a href="' + url + '">' + url + '</a>';
     });
   };
 
-  $.get(url).always(function(data, textStatus, jqXHR){
+  if(!resp.error){
 
-    if(jqXHR.status === 200){
+      var i,
+        items = resp.items;
 
-      try {
+      for(i = 0; i < items.length; i++){
 
-        if( data.feed.entry instanceof Array ){
+        var entry, eventData, venue, startDate, endDate, zeroRegEx, description;
 
-          var i, container;
+        entry = items[i];
 
-          container = {};
+        startDate = window.moment( entry.start.date || entry.start.dateTime );
 
-          for(i = 0; i <= data.feed.entry.length - 1; i++){
+        endDate = window.moment( entry.end.date || entry.end.dateTime );
 
-            var entry, eventData, venue, startDate, endDate, zeroRegEx, description;
+        zeroRegEx = /\-0/g;
 
-            entry = data.feed.entry[i];
+        if(typeof entry.location === 'string'){
 
-            startDate = moment( entry.gd$when[0].startTime );
-
-            endDate = moment( entry.gd$when[0].endTime );
-
-            zeroRegEx = /\-0/g;
-
-            if(typeof entry.gd$where[0].valueString === 'string'){
-
-              venue = entry.gd$where[0].valueString.split(' /')[0];
-
-            }
-
-            description = entry.content.$t.split('-- ')['1'].trim().replace(/\r?\n|\r/g, '');
-
-            eventData = {
-
-              title: entry.title.$t,
-
-              link: entry.content.$t.split(' --')[0],
-
-              cityState: entry.gd$where[0].valueString.split('/ ')[1],
-
-              startMonth: startDate.format('MMM'),
-
-              startDay: startDate.format('D'),
-
-              endMonth: endDate.format('MMM'),
-
-              endDay: endDate.format('D'),
-
-              endYear: endDate.format('YYYY'),
-
-              description: htmlDecode( description ),
-
-              venue: venue
-
-            };
-
-            templateContext.events.push(eventData);
-
-          }
-
-          //console.log(window.optly.mrkt.templates.eventDisplay(templateContext));
-
-          $(div).html(window.optly.mrkt.templates.eventDisplay(templateContext));
-
-        } else {
-
-          //report error to google analytics
-          window.analytics.track(window.location.pathname, {
-            category: 'api error',
-            label: 'google cal api data.feed.entry not array: ' + typeof(data.feed.entry)
-          }, {
-            integrations: {
-              Marketo: false
-            }
-          });
+          venue = entry.location.split(' /')[0];
 
         }
 
-      } catch (error) {
+        description = entry.description.split('-- ')['1'].trim().replace(/\r?\n|\r/g, '');
 
-        //report error to google analytics
-        window.analytics.track(window.location.pathname, {
-          category: 'api error',
-          label: 'google cal reponse contains invalid json'
-        }, {
-          integrations: {
-            Marketo: false
-          }
-        });
+        eventData = {
 
+          title: entry.summary,
+
+          link: entry.description.split(' --')[0],
+
+          cityState: entry.location.split('/ ')[1],
+
+          startMonth: startDate.format('MMM'),
+
+          startDay: startDate.format('D'),
+
+          endMonth: endDate.format('MMM'),
+
+          endDay: endDate.format('D'),
+
+          endYear: endDate.format('YYYY'),
+
+          description: htmlDecode( description ),
+
+          venue: venue
+
+        };
+
+        if(startDate.isAfter(currentDateTime)) {
+          futureEvents.push(eventData);
+        } else {
+          pastEvents.push(eventData);
+        }
+
+      } //end for loop
+
+      //reverse past events
+      pastEvents.reverse();
+
+      if(futureEvents.length > 30) {
+        futureEvents.splice(30);
       }
+
+      if(pastEvents.length > 30) {
+        pastEvents.splice(0, pastEvents.length - 30);
+      }
+
+      templateContext.events = futureEvents;
+
+      $(div).html(window.optly.mrkt.templates.eventDisplay(templateContext));
+      
+      $('body').delegate('#get-past-events', 'click', function(e){
+        e.preventDefault();
+        $('#get-future-events').parent().removeClass('hide-events-link');
+        $(this).parent().addClass('hide-events-link');
+        templateContext.events = pastEvents;
+        $(div).html(window.optly.mrkt.templates.eventDisplay(templateContext));
+      });
+      
+      $('body').delegate('#get-future-events', 'click', function(e){
+        e.preventDefault();
+        $('#get-past-events').parent().removeClass('hide-events-link');
+        $(this).parent().addClass('hide-events-link');
+        templateContext.events = futureEvents;
+        $(div).html(window.optly.mrkt.templates.eventDisplay(templateContext));
+      });
 
     } else {
 
-      //report non 200 to google analytics
+      //report error to google analytics
       window.analytics.track(window.location.pathname, {
         category: 'api error',
-        label: 'google cal reponse not 200: ' + jqXHR.status
+        label: 'google cal api error: ' + typeof resp.error === 'object' ? JSON.stringify(resp.error) : resp.error
       }, {
         integrations: {
           Marketo: false
@@ -121,17 +121,35 @@ window.optly.mrkt.events.showEvents = function(url, div){
 
     }
 
-  });
-
 };
 
-//show future events
-window.optly.mrkt.events.showEvents('https://www.google.com/calendar/feeds/optimizely.com_hh3e0hadjvjs9gh34mdlevverk@group.calendar.google.com/public/full?alt=json&orderby=starttime&max-results=30&singleevents=true&sortorder=ascending&futureevents=true', '#future-events-cont');
+function makeApiCall() {
+  gapi.client.load('calendar', 'v3', function() {
+    var request = gapi.client.calendar.events.list({
+      'calendarId': calendarId,
+      'orderBy': 'startTime',
+      'singleEvents': true
+    });
 
-$('body').delegate('#get-past-events', 'click', function(e){
+    request.execute(function(resp) {
+      //show future events
+      window.optly.mrkt.events.showEvents(resp, '#future-events-cont');
+    });
+  });
+}
 
-  window.optly.mrkt.events.showEvents('https://www.google.com/calendar/feeds/optimizely.com_hh3e0hadjvjs9gh34mdlevverk@group.calendar.google.com/public/full?alt=json&orderby=starttime&max-results=30&singleevents=true&sortorder=ascending&futureevents=false', '#past-events-cont');
+function gapiLoaded() {
+  gapi.client.setApiKey(apiKey);
+  makeApiCall();
+}
 
-  e.preventDefault();
+function loadGapi() {
+  //recursive hack because onload function isn't working for gapi
+  if(!gapi) {
+    return loadGapi();
+  }
+  gapi.load('auth', gapiLoaded);
+}
 
-});
+loadGapi();
+

--- a/website-guts/assets/js/pages/events.js
+++ b/website-guts/assets/js/pages/events.js
@@ -7,9 +7,9 @@ var calendarId = 'optimizely.com_hh3e0hadjvjs9gh34mdlevverk@group.calendar.googl
 window.optly.mrkt.events.showEvents = function(resp, div){
 
   var htmlDecode,
-    currentDateTime = new Date(),
-    futureEvents = [],
-    pastEvents = [];
+  currentDateTime = new Date(),
+  futureEvents = [],
+  pastEvents = [];
 
   htmlDecode = function(text) {
     var urlRegex = /(https?:\/\/[^\s]+)/g;
@@ -20,98 +20,98 @@ window.optly.mrkt.events.showEvents = function(resp, div){
 
   if(!resp.error) {
 
-      var i,
-          items = resp.items;
+    var i,
+    items = resp.items;
 
-      for(i = 0; i < items.length; i++){
+    for(i = 0; i < items.length; i++){
 
-        var entry, eventData, venue, startDate, endDate, zeroRegEx, description;
+      var entry, eventData, venue, startDate, endDate, zeroRegEx, description;
 
-        entry = items[i];
-        startDate = window.moment( entry.start.date || entry.start.dateTime );
-        endDate = window.moment( entry.end.date || entry.end.dateTime );
-        zeroRegEx = /\-0/g;
+      entry = items[i];
+      startDate = window.moment( entry.start.date || entry.start.dateTime );
+      endDate = window.moment( entry.end.date || entry.end.dateTime );
+      zeroRegEx = /\-0/g;
 
-        if(typeof entry.location === 'string'){
-          venue = entry.location.split(' /')[0];
-        }
-
-        description = entry.description.split('-- ')['1'].trim().replace(/\r?\n|\r/g, '');
-        eventData = {
-          title: entry.summary,
-          link: entry.description.split(' --')[0],
-          cityState: entry.location.split('/ ')[1],
-          startMonth: startDate.format('MMM'),
-          startDay: startDate.format('D'),
-          endMonth: endDate.format('MMM'),
-          endDay: endDate.format('D'),
-          endYear: endDate.format('YYYY'),
-          description: htmlDecode( description ),
-          venue: venue
-        };
-
-        if(startDate.isAfter(currentDateTime)) {
-          futureEvents.push(eventData);
-        } else {
-          pastEvents.push(eventData);
-        }
-
-      } //end for loop
-
-      //reverse past events
-      pastEvents.reverse();
-
-      if(futureEvents.length > 30) {
-        futureEvents.splice(30);
+      if(typeof entry.location === 'string'){
+        venue = entry.location.split(' /')[0];
       }
 
-      if(pastEvents.length > 30) {
-        pastEvents.splice(0, pastEvents.length - 30);
+      description = entry.description.split('-- ')['1'].trim().replace(/\r?\n|\r/g, '');
+      eventData = {
+        title: entry.summary,
+        link: entry.description.split(' --')[0],
+        cityState: entry.location.split('/ ')[1],
+        startMonth: startDate.format('MMM'),
+        startDay: startDate.format('D'),
+        endMonth: endDate.format('MMM'),
+        endDay: endDate.format('D'),
+        endYear: endDate.format('YYYY'),
+        description: htmlDecode( description ),
+        venue: venue
+      };
+
+      if(startDate.isAfter(currentDateTime)) {
+        futureEvents.push(eventData);
+      } else {
+        pastEvents.push(eventData);
       }
 
-      $(div).html(window.optly.mrkt.templates.eventDisplay({events: futureEvents}));
-      
-      $('#get-past-events').on('click', function(e){
-        e.preventDefault();
-        $('#get-future-events').parent().removeClass('hide-events-link');
-        $(this).parent().addClass('hide-events-link');
-        $('#events-cont').find('h3').each(function(i, elm) {
-          if(i) {
-            $(elm).removeClass('hide-upcoming').addClass('hide-past');
-          } else {
-            $(elm).removeClass('hide-past').addClass('hide-upcoming');
-          }
-        });
-        $(div).html(window.optly.mrkt.templates.eventDisplay({events: pastEvents}));
-      });
-      
-      $('#get-future-events').on('click', function(e){
-        e.preventDefault();
-        $('#get-past-events').parent().removeClass('hide-events-link');
-        $(this).parent().addClass('hide-events-link');
-        $('#events-cont').find('h3').each(function(i, elm) {
-          if(i) {
-            $(elm).removeClass('hide-past').addClass('hide-upcoming');
-          } else {
-            $(elm).removeClass('hide-upcoming').addClass('hide-past');
-          }
-        });
-        $(div).html(window.optly.mrkt.templates.eventDisplay({events: futureEvents}));
-      });
+    } //end for loop
 
-    } else {
+    //reverse past events
+    pastEvents.reverse();
 
-      //report error to google analytics
-      window.analytics.track(window.location.pathname, {
-        category: 'api error',
-        label: 'google cal api error: ' + typeof resp.error === 'object' ? JSON.stringify(resp.error) : resp.error
-      }, {
-        integrations: {
-          Marketo: false
-        }
-      });
-
+    if(futureEvents.length > 30) {
+      futureEvents.splice(30);
     }
+
+    if(pastEvents.length > 30) {
+      pastEvents.splice(0, pastEvents.length - 30);
+    }
+
+    $(div).html(window.optly.mrkt.templates.eventDisplay({events: futureEvents}));
+
+    $('#get-past-events').on('click', function(e){
+      e.preventDefault();
+      $('#get-future-events').parent().removeClass('hide-events-link');
+      $(this).parent().addClass('hide-events-link');
+      $('#events-cont').find('h3').each(function(i, elm) {
+        if(i) {
+          $(elm).removeClass('hide-upcoming').addClass('hide-past');
+        } else {
+          $(elm).removeClass('hide-past').addClass('hide-upcoming');
+        }
+      });
+      $(div).html(window.optly.mrkt.templates.eventDisplay({events: pastEvents}));
+    });
+
+    $('#get-future-events').on('click', function(e){
+      e.preventDefault();
+      $('#get-past-events').parent().removeClass('hide-events-link');
+      $(this).parent().addClass('hide-events-link');
+      $('#events-cont').find('h3').each(function(i, elm) {
+        if(i) {
+          $(elm).removeClass('hide-past').addClass('hide-upcoming');
+        } else {
+          $(elm).removeClass('hide-upcoming').addClass('hide-past');
+        }
+      });
+      $(div).html(window.optly.mrkt.templates.eventDisplay({events: futureEvents}));
+    });
+
+  } else {
+
+    //report error to google analytics
+    window.analytics.track(window.location.pathname, {
+      category: 'api error',
+      label: 'google cal api error: ' + typeof resp.error === 'object' ? JSON.stringify(resp.error) : resp.error
+    }, {
+      integrations: {
+        Marketo: false
+      }
+    });
+
+  }
 
 };
 

--- a/website-guts/assets/js/utils/stringify_error.js
+++ b/website-guts/assets/js/utils/stringify_error.js
@@ -1,0 +1,13 @@
+//This extends the Error object, it's in utils just to keep track of it by name
+Object.defineProperty(Error.prototype, 'toJSON', {
+    value: function () {
+        var alt = {};
+
+        Object.getOwnPropertyNames(this).forEach(function (key) {
+            alt[key] = this[key];
+        }, this);
+
+        return alt;
+    },
+    configurable: true
+});

--- a/website/events/index.hbs
+++ b/website/events/index.hbs
@@ -3,6 +3,8 @@ layout: about.hbs
 no_container: true
 seo_title: Events
 visible_title: Events
+script_dependencies: 
+- "https://apis.google.com/js/client.js"
 body_class:
 - events-page
 page_script: events.js
@@ -16,6 +18,7 @@ page_script: events.js
         <h3 class="events-heading-small heading-underline">Past Events</h3>
       </div><!--/#events-cont-->
       <div id="previous-events-cont">
+        <p class="show-future-events hide-events-link">Learn more about Optimizely's upcoming events. <a href="#" id="get-future-events">Load Upcoming Events</a></p>
         <p class="show-past-events">Learn more about Optimizely's past events. <a href="#" id="get-past-events">Load Past Events</a></p>
         <div id="past-events-cont"></div>
       </div><!--/#previous-events-cont-->

--- a/website/events/index.hbs
+++ b/website/events/index.hbs
@@ -13,9 +13,9 @@ page_script: events.js
   <div>
     <article>
       <div id="events-cont">
-        <h3>Upcoming Events</h3>
+        <h3 class="hide-past"><span class="upcoming">Upcoming</span><span class="past">Past</span> Events</h3>
         <div id="future-events-cont"></div>
-        <h3 class="events-heading-small heading-underline">Past Events</h3>
+        <h3 class="events-heading-small heading-underline hide-upcoming"><span class="upcoming">Upcoming</span><span class="past">Past</span> Events</h3>
       </div><!--/#events-cont-->
       <div id="previous-events-cont">
         <p class="show-future-events hide-events-link">Learn more about Optimizely's upcoming events. <a href="#" id="get-future-events">Load Upcoming Events</a></p>


### PR DESCRIPTION
This PR address https://optimizely.atlassian.net/browse/MKT-886 for the broken API request to Google Calendar api for /events.  Google released a v3 api and apparently deprecated the old one. The new API requires:
- a script tag to load the gapi api on the page
- turning on the google calendar integration in the developers console
- generating an public browser API key for the Calendar integration
- enabling domains for this integration

In addition to old functionality I could no longer restrict request to pull past and future data separately. I had to pull all the data and sort it appropriately.  The request is made through the gapi API which returns an object rather than JSON.  Therefore, error reporting logic for JSON parsing of request was no longer necessary.

Additional functionality was added allowing the user to toggle back to future events after they have previously toggled to past events.

To test go to /events and set some breakpoints in the JS to inspect the resp on restructuring of data for past and future events. 