### PR TITLE
Add strict type checking to free trial js.

### DIFF
--- a/website-guts/assets/js/pages/free-trial.js
+++ b/website-guts/assets/js/pages/free-trial.js
@@ -537,21 +537,24 @@ var symExpDict = {
   }
 };
 
-var queryString = window.optly.mrkt.utils.deparam(window.location.href);
+var queryString = window.optly.mrkt.utils.deparam(window.location.search);
 
 if( !!queryString.otm_content ) {
   var content = symExpDict[ queryString.otm_content ];
 
-  if(content.heading) {
-    $('.seo-form-heading').text(content.heading);
+  if(typeof content === 'object'){
+    if(typeof content.heading === 'string'){
+      $('.seo-form-heading').text(content.heading);
+    }
+    if(typeof content.text === 'string'){
+      $('#symmetry_test').text(content.text);
+    }
   }
 
-  if(content.text) {
-    $('#symmetry_test').text(content.text);
-  }
-
-  if(queryString.otm_content === 'eo' || queryString.otm_content === 'brand'){
-    $('.seo-form-subheader').hide();
+  if(typeof queryString === 'object' && queryString.otm_content === 'string'){
+    if(queryString.otm_content === 'eo' || queryString.otm_content === 'brand'){
+      $('.seo-form-subheader').hide();
+    }
   }
 
 }

--- a/website-guts/assets/js/pages/free-trial.js
+++ b/website-guts/assets/js/pages/free-trial.js
@@ -551,7 +551,7 @@ if( !!queryString.otm_content ) {
     }
   }
 
-  if(typeof queryString === 'object' && queryString.otm_content === 'string'){
+  if(typeof queryString === 'object' && typeof queryString.otm_content === 'string'){
     if(queryString.otm_content === 'eo' || queryString.otm_content === 'brand'){
       $('.seo-form-subheader').hide();
     }


### PR DESCRIPTION
Last Friday David and I deployed some code that reports all JavaScript errors on the marketing website to Google Analytics. This uncovered a JavaScript bug on the PPC landing page, specifically with the content symmetry script. The content symmetry script adjusts the text on the PPC landing page based on the message in the ad. I believe this bug has been in production since the launch of the new marketing website. This PR fixes this bug.