### PR TITLE
Make relative paths for dashboard and account in signed in utility nav

### DIFF
--- a/website-guts/templates/client/loggedInUtilityNav.hbs
+++ b/website-guts/templates/client/loggedInUtilityNav.hbs
@@ -1,5 +1,5 @@
 <li class="first">
-  <a href="https://www.optimizely.com/dashboard?project_id={{account_id}}">Dashboard</a>
+  <a href="/dashboard?project_id={{account_id}}">Dashboard</a>
 </li>
 <li id="experiment-nav-item" class="hide-in-mobile " data-show-user-state="logged-in">
     <a href="" class="dropdown-arrow experiments" data-dropdown="experiments">Experiments</a>
@@ -51,7 +51,7 @@
   <a id="mobile-email-nav" class="customer-email" href="/account">{{email.mobile}}</a>
   <ul id="account-dropdown" class="dropdown-menu-top" data-show-dropdown="account">
       <li class="hide-in-mobile">
-        <a href="https://www.optimizely.com/account">Account Settings</a>
+        <a href="/account">Account Settings</a>
       </li>
       <li>
         <a data-logout>Log Out</a>


### PR DESCRIPTION
This PR addresses JIRA https://optimizely.atlassian.net/browse/MKT-835 to remove the hardcode links for dashboard and account in the logged in utility nav.  This is relatively inconsequential now as logged in users cannot redirect back to the marketing site out of the product