### PR TITLE
Remove unnecessary content swap classes to avoid bugs

### DIFF
--- a/website-guts/templates/layouts/wrapper.hbs
+++ b/website-guts/templates/layouts/wrapper.hbs
@@ -147,8 +147,8 @@ layout_modals:
                             <div class="left-nav">
                                 <p>&copy; 2014, Optimizely. All Rights Reserved</p>
                                 <ul id="legalese" class="clearfix">
-                                    <li class="terms"><a href="{{linkPath}}/terms/" id="SL-link-terms">Terms of Service</a> &nbsp;<span class="separater">|</span></li>
-                                    <li><a href="{{linkPath}}/privacy/" id="SL-link-privacy">Privacy Policy</a> &nbsp;<span class="separater">|</span></li>
+                                    <li class="terms"><a href="{{linkPath}}/terms/">Terms of Service</a> &nbsp;<span class="separater">|</span></li>
+                                    <li><a href="{{linkPath}}/privacy/">Privacy Policy</a> &nbsp;<span class="separater">|</span></li>
                                     <li class="security"><a href="{{linkPath}}/security/">Security</a></li>
                                 </ul>
                                 <ul class="social-links">

--- a/website-guts/templates/layouts/wrapper.hbs
+++ b/website-guts/templates/layouts/wrapper.hbs
@@ -147,14 +147,14 @@ layout_modals:
                             <div class="left-nav">
                                 <p>&copy; 2014, Optimizely. All Rights Reserved</p>
                                 <ul id="legalese" class="clearfix">
-                                    <li class="terms"><a href="{{linkPath}}/terms/" id="SL-link-terms" class="SL_swap">Terms of Service</a> &nbsp;<span class="separater">|</span></li>
-                                    <li><a href="{{linkPath}}/privacy/" id="SL-link-privacy" class="SL_swap">Privacy Policy</a> &nbsp;<span class="separater">|</span></li>
+                                    <li class="terms"><a href="{{linkPath}}/terms/" id="SL-link-terms">Terms of Service</a> &nbsp;<span class="separater">|</span></li>
+                                    <li><a href="{{linkPath}}/privacy/" id="SL-link-privacy">Privacy Policy</a> &nbsp;<span class="separater">|</span></li>
                                     <li class="security"><a href="{{linkPath}}/security/">Security</a></li>
                                 </ul>
                                 <ul class="social-links">
-                                    <li><a href="http://twitter.com/optimizely" id="SL-link-twitter" class="twitter SL_swap">Twitter</a></li>
-                                    <li><a href="http://www.facebook.com/optimizely" id="SL-link-facebook" class="facebook SL_swap">Facebook</a></li>
-                                    <li><a href="https://plus.google.com/+optimizely/posts" id="SL-link-gplus" class="google-plus SL_swap">Google+</a></li>
+                                    <li><a href="http://twitter.com/optimizely" class="twitter">Twitter</a></li>
+                                    <li><a href="http://www.facebook.com/optimizely" class="facebook">Facebook</a></li>
+                                    <li><a href="https://plus.google.com/+optimizely/posts" class="google-plus">Google+</a></li>
                                 </ul>
                             </div><!--/.left-->
                             <div class="right-nav">

--- a/website/contact/index.hbs
+++ b/website/contact/index.hbs
@@ -26,7 +26,7 @@ page_script: contact.js
       <div class="columns one-half departments">
         <h5>Social:</h5>
         <a target="_blank" href="http://www.facebook.com/optimizely" id="SL-link-facebook">Find us on Facebook <img src="{{assetsDir}}/img/external.png"></a><br>
-        <a target="_blank" href="http://twitter.com/optimizely" id="SL-link-twitter" class="SL_swap">Follow us on Twitter <img src="{{assetsDir}}/img/external.png"></a>
+        <a target="_blank" href="http://twitter.com/optimizely" id="SL-link-twitter">Follow us on Twitter <img src="{{assetsDir}}/img/external.png"></a>
       </div>
     </div>
     <div class="row">

--- a/website/contact/index.hbs
+++ b/website/contact/index.hbs
@@ -25,8 +25,8 @@ page_script: contact.js
       </div>
       <div class="columns one-half departments">
         <h5>Social:</h5>
-        <a target="_blank" href="http://www.facebook.com/optimizely" id="SL-link-facebook">Find us on Facebook <img src="{{assetsDir}}/img/external.png"></a><br>
-        <a target="_blank" href="http://twitter.com/optimizely" id="SL-link-twitter">Follow us on Twitter <img src="{{assetsDir}}/img/external.png"></a>
+        <a target="_blank" href="http://www.facebook.com/optimizely">Find us on Facebook <img src="{{assetsDir}}/img/external.png"></a><br>
+        <a target="_blank" href="http://twitter.com/optimizely">Follow us on Twitter <img src="{{assetsDir}}/img/external.png"></a>
       </div>
     </div>
     <div class="row">

--- a/website/terms/05/30/2013/index.hbs
+++ b/website/terms/05/30/2013/index.hbs
@@ -143,7 +143,7 @@ visible_title: Terms of Service Agreement
               Address: 631 Howard Street, Suite 100, San Francisco, CA 94105<br>
               Telephone: (415) 322-8378<br>
               Fax: (650) 745-0728<br>
-              Email: <span id="SL-email-copyright"><a href="mailto:copyright@optimizely.com">copyright@optimizely.com</a></span>
+              Email: <span><a href="mailto:copyright@optimizely.com">copyright@optimizely.com</a></span>
             </p>
 
             <p>UNDER FEDERAL LAW, IF YOU KNOWINGLY MISREPRESENT THAT ONLINE MATERIAL IS INFRINGING, YOU MAY BE SUBJECT TO CRIMINAL PROSECUTION FOR PERJURY AND CIVIL PENALTIES, INCLUDING MONETARY DAMAGES, COURT COSTS, AND ATTORNEYS’ FEES.</p>

--- a/website/terms/05/30/2013/index.hbs
+++ b/website/terms/05/30/2013/index.hbs
@@ -143,7 +143,7 @@ visible_title: Terms of Service Agreement
               Address: 631 Howard Street, Suite 100, San Francisco, CA 94105<br>
               Telephone: (415) 322-8378<br>
               Fax: (650) 745-0728<br>
-              Email: <span id="SL-email-copyright" class="SL_swap"><a href="mailto:copyright@optimizely.com">copyright@optimizely.com</a></span>
+              Email: <span id="SL-email-copyright"><a href="mailto:copyright@optimizely.com">copyright@optimizely.com</a></span>
             </p>
 
             <p>UNDER FEDERAL LAW, IF YOU KNOWINGLY MISREPRESENT THAT ONLINE MATERIAL IS INFRINGING, YOU MAY BE SUBJECT TO CRIMINAL PROSECUTION FOR PERJURY AND CIVIL PENALTIES, INCLUDING MONETARY DAMAGES, COURT COSTS, AND ATTORNEYS’ FEES.</p>


### PR DESCRIPTION
@dtothefp this should avoid issues like the social icons in the footer getting messed up... If we ever need these swaps we can always put them back.