### PR TITLE
Add testing fields for IOS Marketo population test

### DIFF
--- a/website-guts/assets/js/utils/oform_globals.js
+++ b/website-guts/assets/js/utils/oform_globals.js
@@ -100,6 +100,8 @@
       Web__c: $('input[type="checkbox"][name="web"]').is(':checked') + '',
       Mobile_Web__c: $('input[type="checkbox"][name="mobile_web"]').is(':checked') + '',
       iOS__c: $('input[type="checkbox"][name="ios"]').is(':checked') + '',
+      iOStestc: $('input[type="checkbox"][name="ios"]').is(':checked') + '',
+      IOSTest2: $('input[type="checkbox"][name="ios"]').is(':checked') + '',
       Android__c: $('input[type="checkbox"][name="android"]').is(':checked') + ''
     };
 


### PR DESCRIPTION
From my phone conversation we determined that:

- we could not figure out to change API name within marketo interface for custom fields
- we are unsure if changing field name in SalesForce resulted in changing the Munchkin API name for the custom field
- we created 2 new custom fields to test the IOS checkbox
- 1 with default created name by Marketo, this seems to have no underscores and lowercase first letter
- 2 we altered the default name and Capitalized the first letter.

#### Default API Name
![screen shot 2015-01-30 at 2 05 52 pm](https://cloud.githubusercontent.com/assets/4656726/5981998/dcbdeac8-a88c-11e4-8006-aa4d533ab94c.png)

#### Custom Capitalized API Name
![screen shot 2015-01-30 at 2 17 29 pm](https://cloud.githubusercontent.com/assets/4656726/5982001/e358c4b6-a88c-11e4-83b2-d85e8935cff2.png)

