### PR TITLE
Add more tracking events for an experiment.

### DIFF
--- a/website-guts/assets/js/layouts/trial-form.js
+++ b/website-guts/assets/js/layouts/trial-form.js
@@ -12,9 +12,25 @@ var xhrInitiationTime;
 
 //track focus on form fields
 $('#seo-form input:not([type="hidden"])').each(function(){
-  $(this).one('blur', function(){
+  $(this).one('focus', function(){
     //put all the information in the event because we'll want to use this as a goal in optimizely
     w.analytics.track($(this).closest('form').attr('id') + ' ' + $(this).attr('name') + ' focus',
+    {
+      category: 'forms'
+    },
+    {
+      integrations: {
+        'Marketo': false
+      }
+    });
+  });
+});
+
+//track blur on form fields
+$('#seo-form input:not([type="hidden"])').each(function(){
+  $(this).one('blur', function(){
+    //put all the information in the event because we'll want to use this as a goal in optimizely
+    w.analytics.track($(this).closest('form').attr('id') + ' ' + $(this).attr('name') + ' blur',
     {
       category: 'forms'
     },

--- a/website-guts/assets/js/pages/mobile.js
+++ b/website-guts/assets/js/pages/mobile.js
@@ -275,3 +275,57 @@ $(function() {
 
 
 });
+
+//track focus on form fields
+$('#mobile-signup-form-bottom input:not([type="hidden"]), #mobile-signup-form-top input:not([type="hidden"])').each(function(){
+  $(this).one('focus', function(){
+    //put all the information in the event because we'll want to use this as a goal in optimizely
+    //send a general focus event to track focus for either the top or bottom form
+    w.analytics.track('mobile-signup-form ' + $(this).attr('name') + ' focus',
+    {
+      category: 'forms'
+    },
+    {
+      integrations: {
+        'Marketo': false
+      }
+    });
+    //send a specific focus event to track focus on either the top or bottom form
+    w.analytics.track($(this).closest('form').attr('id') + ' ' + $(this).attr('name') + ' focus',
+    {
+      category: 'forms'
+    },
+    {
+      integrations: {
+        'Marketo': false
+      }
+    });
+  });
+});
+
+//track blur on form fields
+$('#mobile-signup-form-bottom input:not([type="hidden"]), #mobile-signup-form-top input:not([type="hidden"])').each(function(){
+  $(this).one('blur', function(){
+    //put all the information in the event because we'll want to use this as a goal in optimizely
+    //send a general focus event to track focus for either the top or bottom form
+    w.analytics.track('mobile-signup-form ' + $(this).attr('name') + ' blur',
+    {
+      category: 'forms'
+    },
+    {
+      integrations: {
+        'Marketo': false
+      }
+    });
+    //send a specific focus event to track focus on either the top or bottom form
+    w.analytics.track($(this).closest('form').attr('id') + ' ' + $(this).attr('name') + ' blur',
+    {
+      category: 'forms'
+    },
+    {
+      integrations: {
+        'Marketo': false
+      }
+    });
+  });
+});


### PR DESCRIPTION
This PR is a preparation for an experiment that we are going to run on the mobile product page for ads audience. We are adding more reporting.

Reporting changes to the /mobile page:
1. Added blur reporting
2. Added focus reporting

Reporting changes to the /free-trial page:
1. Changed "blur" to "focus to match the real event happening
2. Added blur reporting

Note that for the /mobile page, since there are two forms, I'm sending out two events, one specific to the form on which it occurred and another that is not specific the form on which it occurred. The latter event helps us understand aggregate behavior and is particularly necessary for the upcoming experiment.