### PR TITLE
add moment helper to fix copyright year in footer

### DIFF
--- a/grunt/assemble.js
+++ b/grunt/assemble.js
@@ -8,7 +8,7 @@ module.exports = {
     environmentIsDev: '<%= grunt.config.get("environmentIsDev") %>',
     data: ['<%= config.content %>/**/*.json', '<%= config.content %>/**/*.yml', '<%= grunt.config.get("environmentData") %>'],
     partials: ['<%= config.guts %>/templates/partials/*.hbs'],
-    helpers: ['<%= config.helpers %>/**/*.js'],
+    helpers: ['<%= config.helpers %>/**/*.js', 'helper-moment'],
   },
   modals: {
     options: {

--- a/package.json
+++ b/package.json
@@ -38,10 +38,11 @@
     "grunt-modernizr": "0.6.0",
     "grunt-s3": "0.2.0-alpha.3",
     "grunt-sass": "0.14.0",
-    "time-grunt": "0.3.2",
     "grunt-userevvd": "0.1.4",
+    "helper-moment": "0.1.3",
     "load-grunt-config": "0.16.0",
     "optimizely-marked": "0.0.4",
+    "time-grunt": "0.3.2",
     "uglify-js": "2.4.15"
   },
   "devDependencies": {

--- a/website-guts/templates/layouts/wrapper.hbs
+++ b/website-guts/templates/layouts/wrapper.hbs
@@ -145,7 +145,7 @@ layout_modals:
                         <p><a class="logo" href="{{linkPath}}/">Optimizely</a></p>
                         <div id="footer-nav-cont">
                             <div class="left-nav">
-                                <p>&copy; 2014, Optimizely. All Rights Reserved</p>
+                              <p>&copy; {{moment format="YYYY"}}, Optimizely. All Rights Reserved</p>
                                 <ul id="legalese" class="clearfix">
                                     <li class="terms"><a href="{{linkPath}}/terms/">Terms of Service</a> &nbsp;<span class="separater">|</span></li>
                                     <li><a href="{{linkPath}}/privacy/">Privacy Policy</a> &nbsp;<span class="separater">|</span></li>


### PR DESCRIPTION
Addresses https://optimizely.atlassian.net/browse/MKT-1006 to dynamically update to the current year for copyright in the footer.

*Note: that upgrading to Assemble v6 we will have to upgrade this helpers https://github.com/helpers/helper-moment/issues/1*