### PR TITLE
Krandolph/sec 136 link slash security to bug bounty site

### DIFF
--- a/website/security/index.hbs
+++ b/website/security/index.hbs
@@ -27,5 +27,8 @@ body_class:
 		</ul>
 		<h4>Trusted by thousands every day</h4>
 		<p>Every day, thousands of companies use Optimizely on their website, generating massive amounts of analytics data. We are a team of qualified professionals working for our customers, and we hope you will become our customer too.</p>
+                <h4>Vulnerability Rewards Program (Bug Bounty)</h4>
+                <p>Found a security vulnerability? We reward security researchers for their hard work finding vulnerabilities in our products. More information <a href="https://www.crowdcurity.com/optimizely">here</a>.
+               </p>
 	</div>
 </div>

--- a/website/security/index.hbs
+++ b/website/security/index.hbs
@@ -27,8 +27,7 @@ body_class:
 		</ul>
 		<h4>Trusted by thousands every day</h4>
 		<p>Every day, thousands of companies use Optimizely on their website, generating massive amounts of analytics data. We are a team of qualified professionals working for our customers, and we hope you will become our customer too.</p>
-                <h4>Vulnerability Rewards Program (Bug Bounty)</h4>
-                <p>Found a security vulnerability? We reward security researchers for their hard work finding vulnerabilities in our products. More information <a href="https://www.crowdcurity.com/optimizely">here</a>.
-               </p>
+		<h4>Vulnerability Rewards Program (Bug Bounty)</h4>
+		<p>Found a security vulnerability? We reward security researchers for their hard work finding vulnerabilities in our products. More information <a href="https://www.crowdcurity.com/optimizely">here</a>.</p>
 	</div>
 </div>


### PR DESCRIPTION
Add a link in /security to our Crowdcurity bug bounty platform.