### PR TITLE
Enhance error tracking for mobile experiment.

### DIFF
--- a/website-guts/assets/js/pages/mobile.js
+++ b/website-guts/assets/js/pages/mobile.js
@@ -206,6 +206,14 @@ $(function() {
     signupMobileMvppTopHelperInst.processingAdd();
     signupMobileMvppTopHelperInst.removeErrors();
     signupMobileMvppTopHelperInst.optionsErrorElm.innerHTML = signupMobileMvppTopHelperInst.errorMessages.DEFAULT;
+    w.analytics.track('/mobile/submit', {
+      category: 'account',
+      label: w.optly.mrkt.utils.trimTrailingSlash(w.location.pathname)
+    }, {
+      integrations: {
+        'Marketo': false
+      }
+    });
     return true;
   });
 
@@ -256,6 +264,14 @@ $(function() {
     signupMobileMvppBottomHelperInst.processingAdd();
     signupMobileMvppBottomHelperInst.removeErrors();
     signupMobileMvppBottomHelperInst.optionsErrorElm.innerHTML = signupMobileMvppBottomHelperInst.errorMessages.DEFAULT;
+    w.analytics.track('/mobile/submit', {
+      category: 'account',
+      label: w.optly.mrkt.utils.trimTrailingSlash(w.location.pathname)
+    }, {
+      integrations: {
+        'Marketo': false
+      }
+    });
     return true;
   });
 

--- a/website-guts/assets/js/pages/mobile.js
+++ b/website-guts/assets/js/pages/mobile.js
@@ -175,6 +175,18 @@ $(function() {
     toggleSrc(imgCache[imgIndex], true);
   });
 
+  //custom validation error reporting handler
+  var validationErrorCustom = function(element){
+    var elementName = element.getAttribute('name');
+    var elementValue = $(element).val();
+    var elementHasValue = elementValue ? 'has value' : 'no value';
+    w.analytics.track('mobile-signup-form ' + elementName + ' error submit', {
+      category: 'form error',
+      label: elementHasValue,
+      value: elementValue.length
+    });
+  };
+
    //Oform for signup top
   var signupMobileMvppTopHelperInst = window.optly.mrkt.form.mobileMvpp({formId: 'mobile-signup-form-top'});
 
@@ -197,7 +209,8 @@ $(function() {
     return true;
   });
 
-  signupFormTop.on('validationerror', function(elm) {
+  signupFormTop.on('validationerror', function(elm){
+    validationErrorCustom(elm);
     w.optly.mrkt.Oform.validationError(elm);
     signupMobileMvppTopHelperInst.showOptionsError();
   });
@@ -247,6 +260,7 @@ $(function() {
   });
 
   signupFormBottom.on('validationerror', function(elm) {
+    validationErrorCustom(elm);
     w.optly.mrkt.Oform.validationError(elm);
     signupMobileMvppBottomHelperInst.showOptionsError();
   });


### PR DESCRIPTION
This gives us the ability to group error on both the top and bottom forms. Without this we couldn't track overall error rate in Optimizely during our next experiment. In the past, on validation error, only this was sent: `mobile-signup-form-top password1 error submit`. With this PR, in addition to that event, it will also send `mobile-signup-form password1 error submit`.

It also ads a submit tracking event in the before function. This will help us measure the `submit : success` ratio.