### PR TITLE
Fade-in for CTA on homepage.

### DIFF
--- a/grunt/modernizr.js
+++ b/grunt/modernizr.js
@@ -5,7 +5,9 @@ module.exports = {
     uglify: true,
     tests: ['teststyles'],
     files: {
-      src: ['<%= config.guts %>/assets/js/**/*.js', '!<%= config.guts %>/assets/js/libraries/*.js']
+      src: ['<%= config.guts %>/assets/js/**/*.js',
+            '!<%= config.guts %>/assets/js/libraries/*.js',
+            '<%= config.guts %>/assets/css/**/*.scss']
     },
     extensibility : {
       addtest: true,
@@ -14,6 +16,9 @@ module.exports = {
       testallprops: true,
     },
     matchCommunityTests: true,
-    parseFiles: true
+    parseFiles: true,
+    extra: {
+      'cssanimations': true
+    }
   }
 };

--- a/website-guts/assets/css/pages/homepage.scss
+++ b/website-guts/assets/css/pages/homepage.scss
@@ -112,6 +112,33 @@ body.home-page {
   }
 }
 
+@keyframes fadeIn {
+  0% {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  100% {
+    opacity: 1;
+    transform: translate(0);
+  }
+}
+
+@media only screen and (min-width: $tablet-min-width){
+  html.cssanimations body.home-page {
+    .fade-in {
+      opacity:0;
+      animation: fadeIn ease 1;
+      animation-fill-mode: forwards;
+      animation-duration: .6s;
+    }
+    .cta-wrap {
+      //-webkit-animation-delay: 0.7s;
+      //-moz-animation-delay: 0.7s;
+      animation-delay: 0.5s;
+    }
+  }
+}
+
 @media only screen and (min-width: $tablet-min-width){
   body.home-page {
     #touch-cta,

--- a/website/index.hbs
+++ b/website/index.hbs
@@ -8,12 +8,14 @@ layout_body_class: false
 ---
 <section id="cta">
   <div class="container">
-    <h1>Make every experience count</h1>
-    <p>One optimization platform for websites and mobile apps</p>
-    <form id="get-started" novalidate autocomplete="off">
-      <input type="email" name="email" placeholder="Work Email" id="email-input">
-      <button type="submit">Test it Out &raquo;</button>
-    </form>
+    <div class="cta-wrap fade-in">
+      <h1>Make every experience count</h1>
+      <p>One optimization platform for websites and mobile apps</p>
+      <form id="get-started" novalidate autocomplete="off">
+        <input type="email" name="email" placeholder="Work Email" id="email-input">
+        <button type="submit">Test it Out &raquo;</button>
+      </form>
+    </div><!--/.cta-wrap-->
   </div><!--/.container-->
 </section><!--/#cta-->
 <section class="reasons">


### PR DESCRIPTION
This PR adds a small delay and fade-in for the CTA on the homepage. This is so that we can pull the Demandbase information and update the CTA language before the content fades in. It helps us avoid the so-called flash of unstyled content.