### PR TITLE
Modify OM reporting

### DIFF
--- a/website-guts/assets/js/om/layouts/original.js
+++ b/website-guts/assets/js/om/layouts/original.js
@@ -10,6 +10,8 @@ d.getElementById('hidden').value = 'touched';
 
 var xhrInitiationTime;
 
+w.optly.mrkt.formHadError = false;
+
 //track focus on form fields
 $('#seo-form input:not([type="hidden"])').each(function(){
   $(this).one('blur', function(){
@@ -48,6 +50,7 @@ w.optly.mrkt.trialForm = new Oform({
   return w.optly.mrkt.Oform.before();
 }).on('validationerror', function(element){
   w.optly.mrkt.Oform.validationError(element);
+  w.optly.mrkt.formHadError = true;
   //w.alert('validation error: ' + element.getAttribute('name'));
 }).on('error', function(){
   $('#seo-form .error-message').text('An unknown error occured.');
@@ -180,20 +183,22 @@ w.optly.mrkt.trialForm = new Oform({
 });
 
 var validateOnBlur = function(isValid, element){
-  w.optly.mrkt.trialForm.options.adjustClasses(element, isValid);
-  var elementValue = $(element).val();
-  var elementHasValue = elementValue ? 'has value' : 'no value';
-  if(!isValid){
-    w.optly.mrkt.formHadError = true;
-    w.analytics.track($(element).closest('form').attr('id') + ' ' + $(element).attr('name') + ' error blur', {
-      category: 'form error',
-      label: elementHasValue,
-      value: elementValue.length
-    }, {
-      integrations: {
-        Marketo: false
-      }
-    });
+  if($(element).val()){
+    w.optly.mrkt.trialForm.options.adjustClasses(element, isValid);
+    var elementValue = $(element).val();
+    var elementHasValue = elementValue ? 'has value' : 'no value';
+    if(!isValid){
+      w.optly.mrkt.formHadError = true;
+      w.analytics.track($(element).closest('form').attr('id') + ' ' + $(element).attr('name') + ' error blur', {
+        category: 'form error',
+        label: elementHasValue,
+        value: elementValue.length
+      }, {
+        integrations: {
+          Marketo: false
+        }
+      });
+    }
   }
 };
 

--- a/website-guts/assets/js/om/layouts/original.js
+++ b/website-guts/assets/js/om/layouts/original.js
@@ -13,9 +13,27 @@ var xhrInitiationTime;
 w.optly.mrkt.formHadError = false;
 
 //track focus on form fields
+//track focus on form fields
+$('#seo-form input:not([type="hidden"])').each(function(){
+  $(this).one('focus', function(){
+    //put all the information in the event because we'll want to use this as a goal in optimizely
+    w.analytics.track($(this).closest('form').attr('id') + ' ' + $(this).attr('name') + ' focus',
+    {
+      category: 'forms'
+    },
+    {
+      integrations: {
+        'Marketo': false
+      }
+    });
+  });
+});
+
+//track blur on form fields
 $('#seo-form input:not([type="hidden"])').each(function(){
   $(this).one('blur', function(){
-    window.analytics.track($(this).closest('form').attr('id') + ' ' + $(this).attr('name') + ' focus',
+    //put all the information in the event because we'll want to use this as a goal in optimizely
+    w.analytics.track($(this).closest('form').attr('id') + ' ' + $(this).attr('name') + ' blur',
     {
       category: 'forms'
     },

--- a/website-guts/assets/js/om/layouts/original.js
+++ b/website-guts/assets/js/om/layouts/original.js
@@ -45,6 +45,30 @@ $('#seo-form input:not([type="hidden"])').each(function(){
   });
 });
 
+//track change on form fields
+$('#seo-form input:not([type="hidden"])').each(function(){
+  var element = this;
+  var continuallyCheckForValue = setInterval(function(){
+    if($(element).val()){
+      clearInterval(continuallyCheckForValue);
+      w.analytics.track(element.closest('form').attr('id') + ' ' + $(this).attr('name') + ' value changed', {
+        category: 'forms'
+      },{
+        integrations: {
+          'Marketo': false
+        }
+      });
+      w.analytics.track($(this).closest('form').attr('id') + ' value engagement', {
+        category: 'forms'
+      },{
+          integrations: {
+            'Marketo': false
+          }
+      });
+    }
+  }, 1000);
+});
+
 //form
 w.optly.mrkt.trialForm = new Oform({
   selector: '#seo-form',


### PR DESCRIPTION
Three changes:

1. Doesn't show validation error on blur if the field has no value (this is how the old page does it). To test focus into both the email and URL fields, don't enter a value, then focus out, you should not see any red/validation error. Then enter an invalid value in URL and email fields (like "t"), focus out, then see the validation errors. 

2. Adds a `seo-form success after error true` or `seo-form success after error false` to track if the person that submitted the form successfully encountered a validation error. This can only be tested in production.

3. Fixes/adds focus and blur reporting. You can see in the diff that the existing focus reporting was fucked up because it was set to track blur, but was reporting focus.

4. Adds `change engagement` events to track when the user puts a value into each and any form field.