### PR TITLE
add swap and hide tags for japan pricing swap

### DIFF
--- a/website-guts/templates/partials/feature_list.hbs
+++ b/website-guts/templates/partials/feature_list.hbs
@@ -25,10 +25,10 @@
     </div>
     <div class="table-body">
       {{#each this.features}}
-        <div class="table-row row">
+      <div {{#is this.title "Multichannel Experiments"}}id="multichannel-cont" {{/is}}class="table-row row{{#is this.title "Multichannel Experiments"}} SL_swap{{/is}}">
           <div class="columns four row-title">
             {{#if this.tooltip}}
-              <p><span title="{{this.tooltip}}" data-tooltip>{{this.title}}</span></p>
+            <p><span {{#is this.title "Multichannel Experiments"}}id="multichannel-text" class="SL_swap" {{/is}}title="{{this.tooltip}}" data-tooltip>{{this.title}}</span></p>
             {{else}}
               <p>{{this.title}}</p>
             {{/if}}

--- a/website-guts/templates/partials/feature_list.hbs
+++ b/website-guts/templates/partials/feature_list.hbs
@@ -25,7 +25,7 @@
     </div>
     <div class="table-body">
       {{#each this.features}}
-      <div {{#is this.title "Mobile Developer Tools"}}id="SL_mobile-dev-cont" {{/is}}class="table-row row{{#is this.title "Multichannel Experiments"}} SL_swap{{/is}}">
+      <div {{#is this.title "Mobile Developer Tools"}}id="SL_mobile-dev-cont" {{/is}}class="table-row row{{#is this.title "Mobile Developer Tools"}} SL_swap{{/is}}">
           <div class="columns four row-title">
             {{#if this.tooltip}}
             <p><span {{#is this.title "Multichannel Experiments"}}id="SL_multichannel-text" class="SL_swap" {{/is}}title="{{this.tooltip}}" data-tooltip>{{this.title}}</span></p>

--- a/website-guts/templates/partials/feature_list.hbs
+++ b/website-guts/templates/partials/feature_list.hbs
@@ -25,10 +25,10 @@
     </div>
     <div class="table-body">
       {{#each this.features}}
-      <div {{#is this.title "Multichannel Experiments"}}id="multichannel-cont" {{/is}}class="table-row row{{#is this.title "Multichannel Experiments"}} SL_swap{{/is}}">
+      <div {{#is this.title "Mobile Developer Tools"}}id="SL_mobile-dev-cont" {{/is}}class="table-row row{{#is this.title "Multichannel Experiments"}} SL_swap{{/is}}">
           <div class="columns four row-title">
             {{#if this.tooltip}}
-            <p><span {{#is this.title "Multichannel Experiments"}}id="multichannel-text" class="SL_swap" {{/is}}title="{{this.tooltip}}" data-tooltip>{{this.title}}</span></p>
+            <p><span {{#is this.title "Multichannel Experiments"}}id="SL_multichannel-text" class="SL_swap" {{/is}}title="{{this.tooltip}}" data-tooltip>{{this.title}}</span></p>
             {{else}}
               <p>{{this.title}}</p>
             {{/if}}

--- a/website/features-and-plans/index.hbs
+++ b/website/features-and-plans/index.hbs
@@ -64,11 +64,11 @@ og_description:
     {{#each benefits}}
     <div class="benefit-item four" style="background-image: url('{{icon}}')">
       <h3>{{title}}</h3>
-      <p{{#is @index 1}} id="powerful-pricing-text" class="SL_swap"{{/is}}>{{desc}}</p>
+      <p{{#is @index 1}} id="SL_powerful-text" class="SL_swap"{{/is}}>{{desc}}</p>
     </div>
     {{/each}}
   </div>
-  <p class="asterisk SL_hide">{{asterisk}}</p>
+  <p id="SL_android-coming-soon" class="asterisk SL_swap">{{asterisk}}</p>
 </section>
 {{/with}}
 

--- a/website/features-and-plans/index.hbs
+++ b/website/features-and-plans/index.hbs
@@ -64,11 +64,11 @@ og_description:
     {{#each benefits}}
     <div class="benefit-item four" style="background-image: url('{{icon}}')">
       <h3>{{title}}</h3>
-      <p>{{desc}}</p>
+      <p{{#is @index 1}} id="powerful-pricing-text" class="SL_swap"{{/is}}>{{desc}}</p>
     </div>
     {{/each}}
   </div>
-  <p class="asterisk">{{asterisk}}</p>
+  <p class="asterisk SL_hide">{{asterisk}}</p>
 </section>
 {{/with}}
 

--- a/website/pricing/index.hbs
+++ b/website/pricing/index.hbs
@@ -63,11 +63,11 @@ og_description: "Get started optimizing instantly, or build a custom plan for yo
     {{#each benefits}}
     <div class="benefit-item four" style="background-image: url('{{icon}}')">
       <h3>{{title}}</h3>
-      <p>{{desc}}</p>
+      <p{{#is @index 1}} id="powerful-pricing-text" class="SL_swap"{{/is}}>{{desc}}</p>
     </div>
     {{/each}}
   </div>
-  <p class="asterisk">{{asterisk}}</p>
+  <p class="asterisk SL_hide">{{asterisk}}</p>
 </section>
 {{/with}}
 

--- a/website/pricing/index.hbs
+++ b/website/pricing/index.hbs
@@ -63,11 +63,11 @@ og_description: "Get started optimizing instantly, or build a custom plan for yo
     {{#each benefits}}
     <div class="benefit-item four" style="background-image: url('{{icon}}')">
       <h3>{{title}}</h3>
-      <p{{#is @index 1}} id="powerful-pricing-text" class="SL_swap"{{/is}}>{{desc}}</p>
+      <p{{#is @index 1}} id="SL_powerful-text" class="SL_swap"{{/is}}>{{desc}}</p>
     </div>
     {{/each}}
   </div>
-  <p class="asterisk SL_hide">{{asterisk}}</p>
+  <p id="SL_android-coming-soon" class="asterisk SL_swap">{{asterisk}}</p>
 </section>
 {{/with}}
 


### PR DESCRIPTION
This PR addresses https://optimizely.atlassian.net/browse/MKT-1284 for swapping mobile related content on the pricing page for Japan.  

- added SL_swap on `/pricing` and `/features-and-plans` for "powerful" container content `id="powerful-pricing-text"`
- added SL_hide for `asterick` class `<p>` tag containing text about android
- added SL_swap for multichannel experience text `id="multichannel-text"`
- added SL_swap for multichannel experience text container in order to change the checkbox `id="multichannel-cont"`