### PR TITLE
Manually activate email verification experiment.

### DIFF
--- a/website-guts/assets/js/components/modal-signup.js
+++ b/website-guts/assets/js/components/modal-signup.js
@@ -2,7 +2,7 @@ var signupDialogHelperInst = window.optly.mrkt.form.createAccount({formId: 'sign
 
 w.optly.mrkt.activeModals = {};
 
-w.optly.mrkt.activeModals.signup = new Oform({
+w.optly.mrkt.activeModals['signup-form'] = new Oform({
   selector: '#signup-form',
   customValidation: {
     password1: function(elm) {
@@ -14,7 +14,7 @@ w.optly.mrkt.activeModals.signup = new Oform({
   }
 });
 
-w.optly.mrkt.activeModals.signup.on('before', function() {
+w.optly.mrkt.activeModals['signup-form'].on('before', function() {
   //set the hidden input value
   signupDialogHelperInst.formElm.querySelector('[name="hidden"]').value = 'touched';
   signupDialogHelperInst.processingAdd();
@@ -24,7 +24,7 @@ w.optly.mrkt.activeModals.signup.on('before', function() {
   return true;
 });
 
-w.optly.mrkt.activeModals.signup.on('validationerror', function(elm) {
+w.optly.mrkt.activeModals['signup-form'].on('validationerror', function(elm) {
   w.optly.mrkt.Oform.validationError(elm);
   signupDialogHelperInst.showOptionsError({error: 'DEFAULT'});
   if(!signupDialogHelperInst.characterMessageElm.classList.contains('oform-error-show')) {
@@ -32,7 +32,7 @@ w.optly.mrkt.activeModals.signup.on('validationerror', function(elm) {
   }
 });
 
-w.optly.mrkt.activeModals.signup.on('error', function() {
+w.optly.mrkt.activeModals['signup-form'].on('error', function() {
   signupDialogHelperInst.processingRemove({callee: 'error'});
   signupDialogHelperInst.showOptionsError({error: 'UNEXPECTED'});
   window.analytics.track('create account xhr error', {
@@ -45,9 +45,9 @@ w.optly.mrkt.activeModals.signup.on('error', function() {
   });
 }.bind(signupDialogHelperInst));
 
-w.optly.mrkt.activeModals.signup.on('load', signupDialogHelperInst.load.bind(signupDialogHelperInst));
+w.optly.mrkt.activeModals['signup-form'].on('load', signupDialogHelperInst.load.bind(signupDialogHelperInst));
 
-w.optly.mrkt.activeModals.signup.on('done', function() {
+w.optly.mrkt.activeModals['signup-form'].on('done', function() {
   if (document.body.classList.contains('oform-error')) {
     signupDialogHelperInst.processingRemove({callee: 'done'});
   }

--- a/website-guts/assets/js/components/modals.js
+++ b/website-guts/assets/js/components/modals.js
@@ -169,6 +169,10 @@ window.optly.mrkt.modal.open = function(modalArgs) {
     }
   });
 
+  if(typeof modalArgs.callback === 'function'){
+    modalArgs.callback();
+  }
+
 };
 
 window.optly.mrkt.modal.close = function(modalArgs) {

--- a/website-guts/assets/js/pages/feature-list.js
+++ b/website-guts/assets/js/pages/feature-list.js
@@ -101,7 +101,7 @@ var updatePlanInfo = function(){
 };
 
 w.optly_q.push([updatePlanInfo]);
-w.optly.mrkt.activeModals.signup.remove();
+w.optly.mrkt.activeModals['signup-form'].remove();
 var signupHelper = w.optly.mrkt.form.createAccount({formId: 'signup-form', dialogId: 'signup-dialog'});
 w.optly.mrkt.activeModals = w.optly.mrkt.activeModals || {};
 

--- a/website-guts/assets/js/pages/features-and-plans.js
+++ b/website-guts/assets/js/pages/features-and-plans.js
@@ -111,7 +111,7 @@ var updatePlanInfo = function(){
 };
 
 w.optly_q.push([updatePlanInfo]);
-w.optly.mrkt.activeModals.signup.remove();
+w.optly.mrkt.activeModals['signup-form'].remove();
 var signupHelper = w.optly.mrkt.form.createAccount({formId: 'signup-form', dialogId: 'signup-dialog'});
 w.optly.mrkt.activeModals = w.optly.mrkt.activeModals || {};
 

--- a/website-guts/assets/js/pages/homepage.js
+++ b/website-guts/assets/js/pages/homepage.js
@@ -5,7 +5,12 @@ $('#get-started').submit(function(e){
   var inputVal = $('#get-started input[type="email"]').val();
 
   if( inputVal ){
-    w.optly.mrkt.modal.open({ modalType: 'signup' });
+    w.optly.mrkt.modal.open({
+      modalType: 'signup',
+      callback: function(){
+        w.optimizely.push(['activate', 2548130011]);
+      }
+    });
     d.body.classList.add('test-it-out-success');
     $('input[type="email"]').val(inputVal);
   } else {

--- a/website-guts/assets/js/pages/pricing.js
+++ b/website-guts/assets/js/pages/pricing.js
@@ -111,7 +111,7 @@ var updatePlanInfo = function(){
 };
 
 w.optly_q.push([updatePlanInfo]);
-w.optly.mrkt.activeModals.signup.remove();
+w.optly.mrkt.activeModals['signup-form'].remove();
 var signupHelper = w.optly.mrkt.form.createAccount({formId: 'signup-form', dialogId: 'signup-dialog'});
 w.optly.mrkt.activeModals = w.optly.mrkt.activeModals || {};
 

--- a/website-guts/assets/js/utils/form_helpers/form_helper_factory.js
+++ b/website-guts/assets/js/utils/form_helpers/form_helper_factory.js
@@ -200,6 +200,19 @@ window.optly.mrkt.form.HelperFactory = function(scopeObj) {
         if(resp && resp.error) {
           // if the server response has an error property
           this.showOptionsError({serverMessage: resp.error});
+          //handle invalid emails
+          if(resp.error === 'Please enter a real email address.'){
+            w.analytics.track('email not valid', {
+              category: $(this.formElm).attr('action') + '/invalid-email',
+              label: w.optly.mrkt.utils.trimTrailingSlash(w.location.pathname)
+            });
+            if(typeof w.optly.mrkt.activeModals[$(this.formElm).attr('id')] === 'object'){
+              var oFormInstance = $(this.formElm).attr('id');
+              var element = $(this.formElm).find('input[name="email"]')[0];
+              w.optly.mrkt.activeModals[oFormInstance].options.adjustClasses(element, false);
+              $(this.formElm).find('.email-related').text(resp.error);
+            }
+          }
         } else {
           this.showOptionsError({error: 'UNEXPECTED'});
         }

--- a/website-guts/assets/js/utils/form_helpers/form_helper_factory.js
+++ b/website-guts/assets/js/utils/form_helpers/form_helper_factory.js
@@ -207,10 +207,10 @@ window.optly.mrkt.form.HelperFactory = function(scopeObj) {
               label: w.optly.mrkt.utils.trimTrailingSlash(w.location.pathname)
             });
             if(typeof w.optly.mrkt.activeModals[$(this.formElm).attr('id')] === 'object'){
-              var oFormInstance = $(this.formElm).attr('id');
+              var oFormInstance = w.optly.mrkt.activeModals[$(this.formElm).attr('id')];
               var element = $(this.formElm).find('input[name="email"]')[0];
-              w.optly.mrkt.activeModals[oFormInstance].options.adjustClasses(element, false);
-              $(this.formElm).find('.email-related').text(resp.error);
+              oFormInstance.options.adjustClasses(element, false);
+              $(this.formElm).find('.email-related').text(window.optly.tr(resp.error));
             }
           }
         } else {

--- a/website-guts/endpoint-mocks/createAccountInvalidEmail.json
+++ b/website-guts/endpoint-mocks/createAccountInvalidEmail.json
@@ -1,0 +1,1 @@
+{"id":"1c3207b1-f420-46a5-8c64-013c6b40b9fa","succeeded":false,"error":"Please enter a real email address."}


### PR DESCRIPTION
Two changes:

1. Adds a callback to the modal open function
2. Manually activates the new email verification experiment when someone opens the sign up modal window on the homepage
3. Adds a little bit of code that handles not-real email address

#1 and #2 are not testable in local dev.

To test #3, change 83-92 in grunt/connect.js to:

```js
} else if(req.url === '/account/create') {
    if(req.body.email !== 'david.fox-powell@optimizely.com') {
      res.cookie('optimizely_signed_in', '1', {httpOnly: false});
      res.writeHead(400, {'Content-Type': 'application/json'});
      res.end( grunt.file.read('website-guts/endpoint-mocks/createAccountInvalidEmail.json') );
    } else {
      res.writeHead(400, {'Content-Type': 'application/json'});
      res.end( grunt.file.read('website-guts/endpoint-mocks/accountExists.json') );
    }
}
```

The just submit the signup form on the homepage.

Tests are passing :D