### PR TITLE
Add close speaker yml message, style, and markup

### DIFF
--- a/website-guts/assets/css/pages/opticon-speakers.scss
+++ b/website-guts/assets/css/pages/opticon-speakers.scss
@@ -22,7 +22,7 @@ body.opticon-speakers {
   body.opticon-speakers {
     .message-container {
       margin: 20vh auto;
-      width: 80%;;
+      width: 80%;
     }
   }
 }

--- a/website-guts/assets/css/pages/opticon-speakers.scss
+++ b/website-guts/assets/css/pages/opticon-speakers.scss
@@ -1,0 +1,28 @@
+body.opticon-speakers {
+ #outer-wrapper {
+    background-color: $light-blue-bg;
+  }
+  .message-container {
+    margin: 10vh auto;
+    background-color: white;
+    padding: 15px 0px;
+    border: 2px solid gray;
+    h1 {
+      text-align: center;
+    }
+    p {
+      text-align: center;
+      font-size: 1.2em;
+      margin: 70px;
+    }
+  }
+}
+
+@media only screen and (min-width: $tablet-min-width) {
+  body.opticon-speakers {
+    .message-container {
+      margin: 20vh auto;
+      width: 80%;;
+    }
+  }
+}

--- a/website-guts/assets/css/styles.scss
+++ b/website-guts/assets/css/styles.scss
@@ -33,6 +33,7 @@
 @import 'pages/non-profits';
 @import 'pages/opt-out';
 @import 'pages/opticon';
+@import 'pages/opticon-speakers';
 @import 'pages/partners';
 @import 'pages/press';
 @import 'pages/pricing';

--- a/website/opticon/speakers/index.hbs
+++ b/website/opticon/speakers/index.hbs
@@ -1,0 +1,16 @@
+---
+layout: opticon.hbs
+seo_title: Opticon Speakers
+no_container: true
+no_header: true
+page_script: opticon.js
+footer_style: grey
+body_class:
+- opticon-speakers
+external_stylesheets:
+- //cloud.typography.com/7838232/736966/css/fonts.css
+---
+<div class="message-container">
+  <h1>{{speakers_data.title}}</h1>
+  <p>{{{speakers_data.description}}}</p>
+</div>

--- a/website/opticon/speakers/speakers_data.yml
+++ b/website/opticon/speakers/speakers_data.yml
@@ -1,0 +1,6 @@
+title: "The Call for Speakers has ended for Opticon 2015!"
+description: "Thank you for your interest in submitting your session for Opticon 2015.
+  We'd still love to hear your stories and best practices. Please share your insights
+  with us in <a href='https://community.optimizely.com/'>Optiverse</a>, our online community.
+  We frequently comb through the community to find stories that fit might be relevant
+  to upcoming conferences and press opportunities."


### PR DESCRIPTION
The link optimizely.com/opticon/speakers is still in the wild and we need to let users know that the call for speakers is closed. This PR does that.