### PR TITLE
add dest checking helper and smooth scroll for opticon nav

### DIFF
--- a/website-guts/assets/js/pages/opticon.js
+++ b/website-guts/assets/js/pages/opticon.js
@@ -1,5 +1,8 @@
 var urlParams = window.optly.mrkt.utils.deparam(window.location.search);
+
 if (!$.isEmptyObject(urlParams)) {
   var replacementHref = window.optly.mrkt.utils.param('https://opticon2015.eventbrite.com/?ref=elink', urlParams);
   $('#register .cta').attr('href', replacementHref);
 }
+
+$('[smooth-scroll]').on('click', w.optly.mrkt.utils.smoothScroll);

--- a/website-guts/helpers/helper-isDest.js
+++ b/website-guts/helpers/helper-isDest.js
@@ -7,7 +7,7 @@ module.exports.register = function (Handlebars) {
     
     if(base === compare){
        return insertTrue;
-    } else if (insertFalse && linkPath) {
+    } else if (insertFalse && typeof linkPath === 'string') {
        return path.join(linkPath, insertFalse);
     } else {
       return '';

--- a/website-guts/helpers/helper-isDest.js
+++ b/website-guts/helpers/helper-isDest.js
@@ -1,0 +1,16 @@
+var path = require('path');
+//linkPath, dest, compare, insertTrue, insertFalse
+module.exports.register = function (Handlebars) {
+  Handlebars.registerHelper('isDest', function(dest, compare, insertTrue, insertFalse, linkPath) {
+    var base = path.dirname(dest);
+    base = base.substr(base.lastIndexOf('/') + 1);
+    
+    if(base === compare){
+       return insertTrue;
+    } else if (insertFalse && linkPath) {
+       return path.join(linkPath, insertFalse);
+    } else {
+      return '';
+    }
+  });
+};

--- a/website-guts/helpers/helper-isDest.js
+++ b/website-guts/helpers/helper-isDest.js
@@ -1,5 +1,5 @@
 var path = require('path');
-//linkPath, dest, compare, insertTrue, insertFalse
+
 module.exports.register = function (Handlebars) {
   Handlebars.registerHelper('isDest', function(dest, compare, insertTrue, insertFalse, linkPath) {
     var base = path.dirname(dest);

--- a/website-guts/templates/layouts/opticon.hbs
+++ b/website-guts/templates/layouts/opticon.hbs
@@ -9,9 +9,9 @@ layout_body_class: false
     <img class="opticon-logo" src="//d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/opticon/opticon_logo.svg" alt="Opticon 2015">
   </a>
   <ul class="nav-options">
-    <li><a href="{{linkPath}}/opticon#call-for-sponsors">Sponsors</a></li>
-    <li><a href="https://community.optimizely.com/t5/Presentations/bg-p/Presentations">2014 Presentations</a></li>
-    <li><a href="{{linkPath}}/opticon#register">Registration</a></li>
+    <li><a href="{{isDest page.dest 'opticon' '#call-for-sponsors' '/opticon#call-for-sponsors' linkPath}}" {{isDest page.dest "opticon" "smooth-scroll"}}>Sponsors</a></li>
+    <li><a href="//community.optimizely.com/t5/Presentations/bg-p/Presentations">2014 Presentations</a></li>
+    <li><a href="{{isDest page.dest 'opticon' '#register' '/opticon#register' linkPath}}" {{isDest page.dest "opticon" "smooth-scroll"}}>Registration</a></li>
   </ul>
 </nav>
 


### PR DESCRIPTION
@stewsmith I made a mistake, in the layout you have to use `page.dest` and in there its a string not an object like in a page. 

#### To Test:
- add another directory called `opticon-2` or whatever.
- copy the opticon page in there
- start the server and go to `/opticon`. Smooth scroll should work
- go to `/opticon-2` and links should redirect to opticon at the selected links place on the page.