### PR TITLE
Change Oform code for newer version.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "fastclick": "1.0.2",
     "jquery-cookie": "1.4.1",
     "history.js": "1.8.0",
-    "oform": "2.3.2",
+    "oform": "3.0.0",
     "fitvids": "1.1.0"
   }
 }

--- a/website-guts/assets/js/global.js
+++ b/website-guts/assets/js/global.js
@@ -379,7 +379,7 @@ w.optly.mrkt.changePlanHelper = {
 
 		*/
 
-		if(event.target.status === 200){
+		if(event.XHR.status === 200){
 
 			d.body.classList.add('change-plan-success');
 
@@ -434,7 +434,7 @@ w.optly.mrkt.changePlanHelper = {
 			//to do: update the ui for the error
 			w.analytics.track('/pricing/change_plan', {
 				category: 'api error',
-				label: 'pricing change plan status not 200: ' + event.target.status
+				label: 'pricing change plan status not 200: ' + event.XHR.status
 			}, {
 				integrations: {
 					Marketo: false

--- a/website-guts/assets/js/global.js
+++ b/website-guts/assets/js/global.js
@@ -379,7 +379,7 @@ w.optly.mrkt.changePlanHelper = {
 
 		*/
 
-		if(event.XHR.status === 200){
+		if(event.target.status === 200){
 
 			d.body.classList.add('change-plan-success');
 

--- a/website-guts/assets/js/layouts/trial-form.js
+++ b/website-guts/assets/js/layouts/trial-form.js
@@ -127,7 +127,7 @@ w.optly.mrkt.trialForm = new Oform({
       //remove error class from body?
       w.optly.mrkt.Oform.trackLead({
         formElm: '#seo-form',
-        pageData: event.requestPayload,
+        pageData: pageData,
         XHRevent: event.XHR
       });
       w.analytics.track('seo-form success after error ' + w.optly.mrkt.formHadError, {

--- a/website-guts/assets/js/layouts/trial-form.js
+++ b/website-guts/assets/js/layouts/trial-form.js
@@ -98,7 +98,7 @@ w.optly.mrkt.trialForm = new Oform({
       response;
   xhrElapsedTime = new Date() - xhrInitiationTime;
   try {
-    response = JSON.parse(event.target.responseText);
+    response = JSON.parse(event.XHR.responseText);
   } catch(error){
     w.analytics.track(w.optly.mrkt.utils.trimTrailingSlash(w.location.pathname), {
       category: 'api error',
@@ -117,7 +117,7 @@ w.optly.mrkt.trialForm = new Oform({
     'page': w.optly.mrkt.utils.trimTrailingSlash(w.location.pathname)
   });
   if(response){
-    if(event.target.status === 200){
+    if(event.XHR.status === 200){
       var pageData = {
         email: d.getElementById('email').value,
         url: d.getElementById('url').value,
@@ -127,8 +127,8 @@ w.optly.mrkt.trialForm = new Oform({
       //remove error class from body?
       w.optly.mrkt.Oform.trackLead({
         formElm: '#seo-form',
-        pageData: pageData,
-        XHRevent: event
+        pageData: event.requestPayload,
+        XHRevent: event.XHR
       });
       w.analytics.track('seo-form success after error ' + w.optly.mrkt.formHadError, {
         category: 'form'
@@ -164,7 +164,7 @@ w.optly.mrkt.trialForm = new Oform({
       if(!w.optly.mrkt.automatedTest()){
         setTimeout(function(){
           var redirectURL, domain;
-          domain = window.location.hostname;
+          domain = w.location.hostname;
           if(/^www\.optimizely\./.test(domain)){
             //production
             redirectURL = '/edit?url=';
@@ -179,7 +179,7 @@ w.optly.mrkt.trialForm = new Oform({
     } else {
       w.analytics.track(w.optly.mrkt.utils.trimTrailingSlash(w.location.pathname), {
         category: 'api error',
-        label: 'status not 200: ' + event.target.status
+        label: 'status not 200: ' + event.XHR.status
       }, {
         integrations: {
           'Marketo': false

--- a/website-guts/assets/js/om/layouts/original.js
+++ b/website-guts/assets/js/om/layouts/original.js
@@ -131,7 +131,7 @@ w.optly.mrkt.trialForm = new Oform({
       };
       w.optly.mrkt.Oform.trackLead({
         formElm: '#seo-form',
-        pageData: loadEvent.requestPayload,
+        pageData: pageData,
         XHRevent: loadEvent.XHR
       });
       w.analytics.track('seo-form success after error ' + w.optly.mrkt.formHadError, {

--- a/website-guts/assets/js/om/layouts/original.js
+++ b/website-guts/assets/js/om/layouts/original.js
@@ -131,8 +131,8 @@ w.optly.mrkt.trialForm = new Oform({
       };
       w.optly.mrkt.Oform.trackLead({
         formElm: '#seo-form',
-        pageData: pageData,
-        XHRevent: loadEvent
+        pageData: loadEvent.requestPayload,
+        XHRevent: loadEvent.XHR
       });
       w.analytics.track('seo-form success after error ' + w.optly.mrkt.formHadError, {
         category: 'form'
@@ -187,7 +187,7 @@ w.optly.mrkt.trialForm = new Oform({
       //window.alert('non 200 response');
       w.analytics.track(w.optly.mrkt.utils.trimTrailingSlash(w.location.pathname), {
         category: 'api error',
-        label: 'status not 200: ' + event.target.status
+        label: 'status not 200: ' + event.XHR.status
       }, {
         integrations: {
           'Marketo': false

--- a/website-guts/assets/js/pages/webinar.js
+++ b/website-guts/assets/js/pages/webinar.js
@@ -88,7 +88,7 @@ $(function(){
     $('[name="LastName"]').val( name[1] );
     return true;
   }).on('load', function(event){
-    if(event.target.status === 200){
+    if(event.XHR.status === 200){
       w.optly.mrkt.modal.close({
         modalType: 'webinar-signup',
         track: false

--- a/website-guts/assets/js/utils/form_helpers/create_account_helpers.js
+++ b/website-guts/assets/js/utils/form_helpers/create_account_helpers.js
@@ -126,8 +126,8 @@ var createAccountHelper = {
     if(resp) {
       w.optly.mrkt.Oform.trackLead({
         formElm: '#signup-form',
-        pageData: pageData,
-        XHRevent: e
+        pageData: e.requestPayload,
+        XHRevent: e.XHR
       });
 
       this.redirectHelper({

--- a/website-guts/assets/js/utils/form_helpers/create_account_helpers.js
+++ b/website-guts/assets/js/utils/form_helpers/create_account_helpers.js
@@ -126,7 +126,7 @@ var createAccountHelper = {
     if(resp) {
       w.optly.mrkt.Oform.trackLead({
         formElm: '#signup-form',
-        pageData: e.requestPayload,
+        pageData: pageData,
         XHRevent: e.XHR
       });
 

--- a/website-guts/assets/js/utils/form_helpers/form_helper_factory.js
+++ b/website-guts/assets/js/utils/form_helpers/form_helper_factory.js
@@ -165,7 +165,7 @@ window.optly.mrkt.form.HelperFactory = function(scopeObj) {
         responseSuccess = true;
 
       try {
-        resp = JSON.parse(e.target.responseText);
+        resp = JSON.parse(e.XHR.responseText);
       } catch(err) {
         var action = this.formElm.getAttribute('action');
         window.analytics.track(action, {
@@ -178,10 +178,10 @@ window.optly.mrkt.form.HelperFactory = function(scopeObj) {
         });
       }
 
-      if(e.target && e.target.status !== 200) {
+      if(e.XHR && e.XHR.status !== 200) {
         w.analytics.track(this.formElm.getAttribute('action'), {
           category: 'api error',
-          label: 'status not 200: ' + e.target.status
+          label: 'status not 200: ' + e.XHR.status
         }, {
           integrations: {
             Marketo: false

--- a/website-guts/assets/js/utils/form_helpers/mobile_mvpp_helper.js
+++ b/website-guts/assets/js/utils/form_helpers/mobile_mvpp_helper.js
@@ -23,8 +23,8 @@ var mobileMvppHelper = {
     if(resp) {
       w.optly.mrkt.Oform.trackLead({
         formElm: this.formElm,
-        pageData: pageData, 
-        XHRevent: e
+        pageData: e.requestPayload,
+        XHRevent: e.XHR
       });
 
       w.Munchkin.munchkinFunction('visitWebPage', {url: '/event/ios-form-signup'});

--- a/website-guts/assets/js/utils/form_helpers/mobile_mvpp_helper.js
+++ b/website-guts/assets/js/utils/form_helpers/mobile_mvpp_helper.js
@@ -23,7 +23,7 @@ var mobileMvppHelper = {
     if(resp) {
       w.optly.mrkt.Oform.trackLead({
         formElm: this.formElm,
-        pageData: e.requestPayload,
+        pageData: pageData,
         XHRevent: e.XHR
       });
 

--- a/website-guts/assets/js/utils/form_helpers/seo_helpers.js
+++ b/website-guts/assets/js/utils/form_helpers/seo_helpers.js
@@ -27,7 +27,7 @@ var seoHelper = {
       //remove error class from body?
       w.optly.mrkt.Oform.trackLead({
         formElm: this.formElm,
-        pageData: event.requestPayload,
+        pageData: pageData,
         XHRevent: event.XHR
       });
       //[> legacy reporting - to be deprecated <]

--- a/website-guts/assets/js/utils/form_helpers/seo_helpers.js
+++ b/website-guts/assets/js/utils/form_helpers/seo_helpers.js
@@ -27,8 +27,8 @@ var seoHelper = {
       //remove error class from body?
       w.optly.mrkt.Oform.trackLead({
         formElm: this.formElm,
-        pageData: pageData,
-        XHRevent: event
+        pageData: event.requestPayload,
+        XHRevent: event.XHR
       });
       //[> legacy reporting - to be deprecated <]
       w.analytics.track('/free-trial/success', {
@@ -60,7 +60,7 @@ var seoHelper = {
     } else {
       w.analytics.track(w.optly.mrkt.utils.trimTrailingSlash(w.location.pathname), {
         category: 'api error',
-        label: 'status not 200: ' + event.target.status
+        label: 'status not 200: ' + event.XHR.status
       }, {
         integrations: {
           'Marketo': false

--- a/website-guts/assets/js/utils/form_helpers/signin_helpers.js
+++ b/website-guts/assets/js/utils/form_helpers/signin_helpers.js
@@ -78,7 +78,7 @@ var signinHelper = {
     //track signin
     w.analytics.track('acount sign-in', {
       category: 'account',
-      label: window.location.pathname
+      label: w.optly.mrkt.utils.trimTrailingSlash(w.location.pathname)
     }, {
       integrations: {
         Marketo: false
@@ -92,9 +92,9 @@ var signinHelper = {
     //track customer type
     if(resp.subscription_plan) {
       /* legacy reportin - to be deprecated */
-      window.analytics.track('/customer/signed-in', {
+      w.analytics.track('/customer/signed-in', {
         category: 'account',
-        label: w.location.pathname
+        label: w.optly.mrkt.utils.trimTrailingSlash(w.location.pathname)
       }, {
         integrations: {
           Marketo: false
@@ -104,9 +104,9 @@ var signinHelper = {
         url: '/customer/signed-in'
       });
       /* new reporting */
-      window.analytics.track('customer sign in', {
+      w.analytics.track('customer sign in', {
         category: 'account',
-        label: w.location.pathname
+        label: w.optly.mrkt.utils.trimTrailingSlash(w.location.pathname)
       }, {
         integrations: {
           Marketo: false

--- a/website-guts/assets/js/utils/oform_globals.js
+++ b/website-guts/assets/js/utils/oform_globals.js
@@ -68,7 +68,7 @@
     source = w.optly.mrkt.source;
 
     try {
-      response = JSON.parse(XHRevent.target.responseText);
+      response = JSON.parse(XHRevent.responseText);
     } catch(error) {
       if(typeof error === 'object') {
         try {
@@ -78,7 +78,7 @@
         }
       }
       w.analytics.ready(function() {
-        w.analytics.track(window.optly.mrkt.utils.trimTrailingSlash(w.location.pathname) + ':trackLead', {
+        w.analytics.track(w.optly.mrkt.utils.trimTrailingSlash(w.location.pathname) + ':trackLead', {
             category: 'api error',
             label: error
           }, {
@@ -164,7 +164,7 @@
 
     w.analytics.track('/account/create/success', {
       category: 'account',
-      label: window.optly.mrkt.utils.trimTrailingSlash(w.location.pathname)
+      label: w.optly.mrkt.utils.trimTrailingSlash(w.location.pathname)
     }, {
       integrations: {
         Marketo: false
@@ -177,7 +177,7 @@
 
     w.analytics.track('/account/signin', {
       category: 'account',
-      label: window.optly.mrkt.utils.trimTrailingSlash(w.location.pathname)
+      label: w.optly.mrkt.utils.trimTrailingSlash(w.location.pathname)
     }, {
       integrations: {
         'Marketo': false
@@ -224,10 +224,10 @@
     })
     .on('validationerror', w.optly.mrkt.Oform.validationError)
     .on('load', function(event){
-      if(event.target.status === 200){
+      if(event.XHR.status === 200){
         //identify user
         $('body').addClass('oform-success');
-        var response = JSON.parse(event.target.responseText),
+        var response = JSON.parse(event.XHR.responseText),
             email = d.querySelector('[name="email"]').value,
             traffic = d.querySelector('#traffic');
         w.analytics.identify(response.unique_user_id, {
@@ -237,8 +237,8 @@
           phone: d.querySelector('[name="phone"]').value || '',
           company: d.querySelector('[name="company"]').value || '',
           website: d.querySelector('[name="website"]').value || '',
-          utm_Medium__c: window.optly.mrkt.source.utm.medium,
-          otm_Medium__c: window.optly.mrkt.source.otm.medium,
+          utm_Medium__c: w.optly.mrkt.source.utm.medium,
+          otm_Medium__c: w.optly.mrkt.source.otm.medium,
           Demo_Request_Monthly_Traffic__c: traffic.options[traffic.selectedIndex].value || '',
           Inbound_Lead_Form_Type__c: d.querySelector('[name="inboundFormLeadType"]').value,
           token: response.token
@@ -250,7 +250,7 @@
         //track the event
         w.analytics.track('demo requested', {
           category: 'contact form',
-          label: window.optly.mrkt.utils.trimTrailingSlash(w.location.pathname)
+          label: w.optly.mrkt.utils.trimTrailingSlash(w.location.pathname)
         }, {
           integrations: {
             Marketo: true


### PR DESCRIPTION
Updated Oform to 3.0.0, which is a non-backwards compatible release. This is the version that the OM page uses so it's pretty stable.

To verify that this works you should:

1. Run `grunt test`
2. Manually test /resources/live-demo-webinar (this doesn't have UI test)

Might also be good to run through each flow yourself in Chrome to see if any errors pop up in the console.