### PR TITLE
add cookie removal script for amplitude

### DIFF
--- a/website-guts/assets/js/global.js
+++ b/website-guts/assets/js/global.js
@@ -521,6 +521,10 @@ w.optly_q.push([function(){
 
 w.optly.mrkt.formHadError = false;
 
+w.optly.mrkt.deleteCookie = function(name, options) {
+  $.removeCookie(name, options);
+};
+
 //call the utility function to unregister archived experiments from the mixpanel cookie
 w.analytics.ready(w.optly.mrkt.utils.trimMixpanelCookie);
 
@@ -541,4 +545,8 @@ if(w.monitorTiming){
 			}
 		}
 	}, 1000);
+}
+
+if( $.cookie('amplitude_idoptimizely.com') ) {
+  w.optly.mrkt.deleteCookie('amplitude_idoptimizely.com', { path: '/', expires: -5, domain: '.optimizely.com'} );
 }


### PR DESCRIPTION
## To Test:

This is a bit difficult. You can put a breakpoint in the global cookie removal function and check properties. Probably it won't be called though because the `amplitude` cookie won't exist in dev. If you have the `amplitude` cookie in prod probably best to just call the jQuery cookie removal function with the options specified.