### PR TITLE
remove munchkin from track lead

### DIFF
--- a/website-guts/assets/js/om/utils/oform-globals.js
+++ b/website-guts/assets/js/om/utils/oform-globals.js
@@ -50,11 +50,11 @@ w.optly.mrkt.Oform.trackLead = function(args){
   source = w.optly.mrkt.source;
 
   try {
-    response = JSON.parse(XHRevent.XHR.responseText);
+    response = JSON.parse(XHRevent.responseText);
   } catch(e) {
     if(typeof error === 'object') { 
       try { 
-        error = JSON.stringify(err, ['message', 'arguments', 'type', 'name']); 
+        error = JSON.stringify(error, ['message', 'arguments', 'type', 'name']); 
       } catch (innerErr) { 
         error = innerErr.message || 'cannot parse error message'; 
       } 
@@ -132,9 +132,6 @@ w.optly.mrkt.Oform.trackLead = function(args){
       reportingObject[propertyName] = pageData[propertyName];
     }
   }
-
-  //make a raw Munchkin associateLead Request
-  w.Munchkin.munchkinFunction('associateLead', reportingObject, token);
 
   w.analytics.identify(response.unique_user_id, reportingObject, {
     integrations: {

--- a/website-guts/assets/js/utils/oform_globals.js
+++ b/website-guts/assets/js/utils/oform_globals.js
@@ -151,9 +151,6 @@
       }
     }
 
-    //make a raw Munchkin associateLead Request
-    w.Munchkin.munchkinFunction('associateLead', reportingObject, token);
-
     w.analytics.identify(response.unique_user_id, reportingObject, {
       integrations: {
         Marketo: true


### PR DESCRIPTION
This PR removes the `munchkin` calls we were making to `associateLead` because this is now being taken care of by segment.

In addition if fixes two errors on the `om` for the `err` variable and the `XHR` property on the `XHRevent` object