### PR TITLE
Add om-tests to grunt test and grunt ui-test.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,7 +21,8 @@ module.exports = function(grunt) {
         resemble: 'grunt-resemble-cli',
         sass: 'grunt-sass',
         connect: 'grunt-contrib-connect',
-        jasmine_node: 'grunt-jasmine-node'
+        jasmine_node: 'grunt-jasmine-node',
+        open: 'grunt-open'
       }
     },
     data: {
@@ -30,6 +31,10 @@ module.exports = function(grunt) {
     },
     init: true
   });
+
+  grunt.registerTask('om-test', [
+    'open'
+  ]);
 
   grunt.registerTask('staging-deploy', [
     'gitinfo',
@@ -105,14 +110,25 @@ module.exports = function(grunt) {
   ]);
 
   grunt.registerTask('ui-test', function(which) {
-    var task = 'jasmine_node';
-    if (which) task += ':' + which;
+    var jasminTest = 'jasmine_node',
+        tasks = [
+          'config:dev',
+          'jshint:test'
+        ];
 
-    grunt.task.run([
-      'config:dev',
-      'jshint:test',
-      task
-    ]);
+    if(which){
+      if(which !== 'om'){
+        jasminTest += ':' + which;
+        tasks.push(jasminTest);
+      } else if(which === 'om'){
+        tasks.push('om-test');
+      }
+    } else {
+      tasks.push('om-test');
+      tasks.push(jasminTest);
+    }
+
+    grunt.task.run(tasks);
   });
 
   grunt.registerTask('test', [
@@ -130,6 +146,7 @@ module.exports = function(grunt) {
     'autoprefixer',
     'copy',
     'clean:postBuild',
+    'om-test',
     'connect:resemble',
     'jasmine_node',
     'resemble'
@@ -154,7 +171,7 @@ module.exports = function(grunt) {
     var prepare = ['prompt', 'build']
     var compress = ['compress'];
     var git_release_tasks = ['gitfetch', 'forceon', 'gittag', 'gitpush', 'forceoff', 'github-release'];
-    
+
     grunt.task.run(prepare);
     grunt.task.run(compress);
     grunt.task.run(git_release_tasks);

--- a/grunt/open.js
+++ b/grunt/open.js
@@ -1,0 +1,7 @@
+var queryStrings = '?uiTest=true&utm_campaign=utm_campaign_uitest&utm_content=utm_content_uitest&utm_medium=utm_medium_uitest&utm_source=utm_source_uitest&utm_keyword=utm_keyword_uitest&otm_campaign=otm_campaign_uitest&otm_content=btt&otm_medium=otm_medium_uitest&otm_source=otm_source_uitest&otm_keyword=otm_keyword_uitest&signup_platform=signup_platform_uitest';
+module.exports = {
+  firefox: {
+    url: 'http://localhost:9000/dist/om/free-trial/fixture.html' + queryStrings,
+    app: 'Firefox'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "grunt-resemble-cli": "0.0.8",
     "grunt-text-replace": "0.3.12",
     "nightmare": "git+ssh://git@github.com:dtothefp/nightmare.git",
-    "phantomjs": "~1.9.12"
+    "phantomjs": "~1.9.12",
+    "grunt-open": "^0.2.3"
   },
   "licenses": [
     {


### PR DESCRIPTION
Last Thursday I deployed a bug to production that broke all leads on the /om/free-trial page. The new OM tests would have caught this, but for some reason neither David nor I ran the OM tests on the branch so we didn't catch the bug. Obviously we can't afford anymore lead bugs so we need to ensure that the OM tests are always run on every PR.

To prevent this from happening in the future, this PR integrates the OM tests into the `grunt test` and `grunt ui-test` tasks. That means you can run the OM tests in three different ways:

1. `grunt test` while your local sever is NOT running
2. 'grunt ui-test` while your local server IS running - this run all UI tests
3. `grunt ui-test:om` while your local server IS running - this runs only the OM tests

There isn't much of a change for anyone here. As mentioned above, the OM tests will now run if you were running the UI tests with either `grunt test` or `grunt ui-test`. The only change is that you'll now have to verify that the OM tests pass.

**Make sure you run `npm i` after this is merged.**

This is what a passing OM test looks like (no red):

![screen shot 2015-03-07 at 10 09 13 am](https://cloud.githubusercontent.com/assets/150579/6541803/10417432-c4b2-11e4-9c9b-df90a0c78e65.png)
