### PR TITLE
Add prospectus to about page

### DIFF
--- a/website-guts/assets/css/pages/opticon-about.scss
+++ b/website-guts/assets/css/pages/opticon-about.scss
@@ -34,10 +34,10 @@ body.opticon-about {
   .right-paragraph {
     padding: 4%;
     .description-title {
-      min-height: 122px;
+      min-height: 86px;
     }
     .description-text {
-      min-height: 120px;
+      min-height: 153px;
     }
   }
   .confetti-right {

--- a/website/opticon/about/index.hbs
+++ b/website/opticon/about/index.hbs
@@ -33,9 +33,9 @@ external_script:
     <div class="right-paragraph">
       <h3 class="description-title adelle-sans">{{right_paragraph.title}}</h3>
       <p class="description-text adelle-sans">{{right_paragraph.blurb}}</p>
-      <p class="disabled adelle-sans">{{right_paragraph.cta}}</p>
+      <a class="body-button adelle-sans" href="http://pages.optimizely.com/rs/optimizely/images/Opticon_2015_Sponsorship_Prospectus.pdf">{{right_paragraph.cta}}</a>
     </div>
-    </div>
+  </div>
   {{/with}}
 </div>
 

--- a/website/opticon/about/opticon_about.yml
+++ b/website/opticon/about/opticon_about.yml
@@ -6,14 +6,14 @@ top_paragraph:
   cta: "Justify your trip"
 
 left_paragraph:
-  title: "Up your Optimizely game - join us for hands-on training sessions."
+  title: "Join us for hands-on training sessions."
   blurb: "Optimizely training is a great hands-on way to learn best practices for building an optimization strategy and expanding your technical knowledge."
   cta: "Learn more"
 
 right_paragraph:
-  title: "Be a part of the Optimizely customer hero awards."
-  blurb: "The Optie Awards recognize and celebrate customers who create impactful online experiences and empower organizations to turn data into action. Nominate someone today for a 2015 Optie Award!"
-  cta: "Nomination page coming soon."
+  title: "Become an Opticon Sponsor."
+  blurb: "Opticon sponsors have a unique opportunity to engage with 1,000 leaders in the optimization community, grow their business, and set the tone for what will be accomplished in the emergent space of experience optimization."
+  cta: "Download Prospectus"
 
 faq_section:
   title: "FAQs"


### PR DESCRIPTION
We need a link to the sponsorship prospectus. This PR replaces the Opties paragraph (which lacks a CTA) with the prospectus.