### PR TITLE
add urlLike helper to check for valid KB article url

### DIFF
--- a/website-guts/helpers/helper-debug.js
+++ b/website-guts/helpers/helper-debug.js
@@ -1,0 +1,13 @@
+module.exports.register = function (Handlebars)  {
+  Handlebars.registerHelper('debug', function (optionalValue, options)  {
+    console.log('Current Context');
+    console.log('====================');
+    // console.log(this);
+    if (optionalValue) {
+      console.log('Value');
+      console.log('====================');
+      console.log(optionalValue);
+    }
+  });
+};
+

--- a/website-guts/helpers/helper-isUrlLike.js
+++ b/website-guts/helpers/helper-isUrlLike.js
@@ -1,0 +1,13 @@
+module.exports.register = function (Handlebars)  {
+  Handlebars.registerHelper('isUrlLike', function (urlTest, options)  {
+    var reURL = /^(\/\/)([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)$/;
+    var url = urlTest && urlTest.replace('https:', '').replace('http:', '');
+    var isValid = url && reURL.test(url);
+
+    if(isValid) {
+      return options.fn(this);
+    } else {
+      return options.inverse(this);
+    }
+  });
+};

--- a/website-guts/templates/layouts/partners.hbs
+++ b/website-guts/templates/layouts/partners.hbs
@@ -87,11 +87,11 @@ layout_body_class:
             </div>
             {{/if}}
 
-            {{#if kb_article}}
-            <a class="button" href="{{kb_article}}">
+            {{#isUrlLike page.kb_article}}
+            <a class="button" href="{{page.kb_article}}">
               {{{solutions_data.kb_article}}}
             </a>
-            {{/if}}
+            {{/isUrlLike}}
           </div>
         </div>
       </div>


### PR DESCRIPTION
###Purpose
- not allow marketers to enter invalid input for `kb_article` parameter. This is the link to the external article button.
- if the url is not valid https, http, or //something.co the button will not be displayed

###Test
Please test this, the regex was breaking Node build previously
- just run `grunt server as normal`
- got to `partners/technology/liveramp/` and check there is no "Get implementation guide" button
- got to another technology partner page and ensure the button is there with functioning link

![screen shot 2015-03-17 at 12 49 32 pm](https://cloud.githubusercontent.com/assets/4656726/6692578/d538326e-cca3-11e4-8c4c-0e31688015eb.png)
