### PR TITLE
Adding Google+ publisher code to homepage

### DIFF
--- a/website/index.hbs
+++ b/website/index.hbs
@@ -5,6 +5,8 @@ body_class:
 page_script: homepage.js
 layout_script: false
 layout_body_class: false
+meta_tags:
+- '<link rel="publisher" href="https://plus.google.com/113842166556345533815"/>'
 ---
 <section id="cta">
   <div class="container">


### PR DESCRIPTION
Added Google+ publisher meta tag, which links our homepage to our Google+ page