### PR TITLE
remove underline for main-nav top level menu items

### DIFF
--- a/website-guts/assets/css/modules/header.scss
+++ b/website-guts/assets/css/modules/header.scss
@@ -264,6 +264,7 @@ header {
               font-size: 1em;
               line-height: 1.4em;
           }
+          > a:hover {text-decoration: none;}
           ul {
               position: absolute;
               top: 50px;

--- a/website-guts/assets/css/modules/header.scss
+++ b/website-guts/assets/css/modules/header.scss
@@ -6,6 +6,7 @@ header {
         text-align: right;
         & > a {
           display: inline-block;
+          &:hover {text-decoration: none;}
         }
         ul {
           padding-left: 0;


### PR DESCRIPTION
Main nav top level li's had an underline on hover

#### to test
- hover pricing or jobs, these were the problem items