### PR TITLE
upgrade to phantom 2.0 and nightmare 1.7

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -149,7 +149,6 @@ module.exports = function(grunt) {
     'om-test',
     'connect:resemble',
     'jasmine_node',
-    'resemble'
   ]);
 
   grunt.registerTask('default', [

--- a/configs/uiTestConfig.js
+++ b/configs/uiTestConfig.js
@@ -1,3 +1,4 @@
+var phantomPath = require('phantomjs').path;
 var createQueryString = function(params) {
   var queryString = '';
   if(params) {
@@ -38,7 +39,7 @@ module.exports = function(options){
     email: 'testing@optimizely.com',
     retrievePasswordEmail: 'david.fox-powell@optimizely.com',
     password: '1800EatBurritos',
-    phantomPath: require('phantomjs').path,
+    phantomPath: phantomPath.substring(0, phantomPath.lastIndexOf('/') + 1),
     screenshot: function(opts) {
       return options.dirname + '/screenshots/' + opts.imgName + '.jpg';
     },

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "grunt-prompt": "1.3.0",
     "grunt-resemble-cli": "0.0.8",
     "grunt-text-replace": "0.3.12",
-    "nightmare": "git+ssh://git@github.com:dtothefp/nightmare.git",
-    "phantomjs": "~1.9.12",
+    "nightmare": "git+ssh://git@github.com/dtothefp/nightmare.git",
+    "phantomjs": "git+ssh://git@github.com/dtothefp/phantomjs.git",
     "grunt-open": "^0.2.3"
   },
   "licenses": [

--- a/package.json
+++ b/package.json
@@ -54,11 +54,10 @@
     "grunt-github-releaser": "0.1.17",
     "grunt-jasmine-node": "git+ssh://git@github.com:dtothefp/grunt-jasmine-node.git",
     "grunt-prompt": "1.3.0",
-    "grunt-resemble-cli": "0.0.8",
     "grunt-text-replace": "0.3.12",
     "nightmare": "git+ssh://git@github.com/dtothefp/nightmare.git",
     "phantomjs": "git+ssh://git@github.com/dtothefp/phantomjs.git",
-    "grunt-open": "^0.2.3"
+    "grunt-open": "0.2.3"
   },
   "licenses": [
     {


### PR DESCRIPTION
This PR addresses upgrading our Nightmare ^1.7 module and PhantomJS to 2.0.0. We are still pulling Nightmare from my github due to

https://github.com/segmentio/nightmare/issues/120

And we are now pulling the PhantomJS binary from my github because the current PhantomJS node module won't update until PhantomJS 2.0.0 is stable

https://github.com/Medium/phantomjs/issues/288

I adjusted the build script of this module to pull the only working PhantomJS binary for MacOSX I could find. Hopefully when Nightmare and PhantomJS get their act together we can stop pulling from my GH.

#### To Test
```bash
rm -rf node_modules && npm cache clear && npm i
```
or add this alias to your .zshrc 
```
alias rmall='nvm use 0.10 && rm -rf node_modules && npm cache clear && npm i'
```
also if you are using nvm and have a newer version of node than 0.10.26 it would help to `nvm use 0.10.<your version>` as it is much faster install

```
grunt server
grunt ui-test //in separate terminal tab
```

Also, check the screenshots. You will see that Flex Box stuff in the background is NOT broken
