### PR TITLE
Hound config

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -3,6 +3,7 @@ java_script:
 
 scss:
   enabled: true
+  config_file: .scss-style.yml
 
 ruby:
   enabled: false

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,12 @@
+java_script:
+  enabled: false
+
+scss:
+  enabled: true
+
+ruby:
+  enabled: false
+
+coffee_script:
+  enabled: false
+

--- a/.scss-style.yml
+++ b/.scss-style.yml
@@ -1,0 +1,145 @@
+scss_files: "**/*.scss"
+linters:
+  BangFormat:
+    enabled: true
+    space_before_bang: true
+    space_after_bang: false
+  BorderZero:
+    enabled: false
+    convention: zero
+  ColorKeyword:
+    enabled: true
+    severity: warning
+  ColorVariable:
+    enabled: true
+  Comment:
+    enabled: true
+  DebugStatement:
+    enabled: true
+  DeclarationOrder:
+    enabled: true
+  DuplicateProperty:
+    enabled: true
+  ElsePlacement:
+    enabled: true
+    style: same_line
+  EmptyLineBetweenBlocks:
+    enabled: true
+    ignore_single_line_blocks: true
+  EmptyRule:
+    enabled: true
+  FinalNewline:
+    enabled: true
+    present: true
+  HexLength:
+    enabled: false
+    style: short
+  HexNotation:
+    enabled: true
+    style: lowercase
+  HexValidation:
+    enabled: true
+  IdSelector:
+    enabled: true
+  ImportantRule:
+    enabled: true
+  ImportPath:
+    enabled: true
+    leading_underscore: false
+    filename_extension: false
+  Indentation:
+    enabled: true
+    allow_non_nested_indentation: false
+    character: space
+    width: 2
+  LeadingZero:
+    enabled: true
+    style: include_zero
+  MergeableSelector:
+    enabled: true
+    force_nesting: true
+  NameFormat:
+    enabled: true
+    allow_leading_underscore: true
+    convention: hyphenated_lowercase
+  NestingDepth:
+    enabled: true
+    max_depth: 4
+    severity: warning
+  PlaceholderInExtend:
+    enabled: false
+  PropertyCount:
+    enabled: true
+    include_nested: false
+    max_properties: 10
+  PropertySortOrder:
+    enabled: true
+    ignore_unspecified: false
+    severity: warning
+    separate_groups: false
+  PropertySpelling:
+    enabled: true
+    extra_properties: []
+  QualifyingElement:
+    enabled: true
+    allow_element_with_attribute: false
+    allow_element_with_class: false
+    allow_element_with_id: false
+    severity: warning
+  SelectorDepth:
+    enabled: true
+    max_depth: 2
+    severity: warning
+  SelectorFormat:
+    enabled: true
+    convention: hyphenated_lowercase
+  Shorthand:
+    enabled: true
+    severity: warning
+  SingleLinePerProperty:
+    enabled: true
+    allow_single_line_rule_sets: true
+  SingleLinePerSelector:
+    enabled: true
+  SpaceAfterComma:
+    enabled: true
+  SpaceAfterPropertyColon:
+    enabled: true
+    style: one_space
+  SpaceAfterPropertyName:
+    enabled: true
+  SpaceBeforeBrace:
+    enabled: true
+    style: space
+    allow_single_line_padding: false
+  SpaceBetweenParens:
+    enabled: true
+    spaces: 0
+  StringQuotes:
+    enabled: true
+    style: double_quotes
+  TrailingSemicolon:
+    enabled: true
+  TrailingZero:
+    enabled: false
+  UnnecessaryMantissa:
+    enabled: true
+  UnnecessaryParentReference:
+    enabled: true
+  UrlFormat:
+    enabled: true
+  UrlQuotes:
+    enabled: true
+  VariableForProperty:
+    enabled: false
+    properties: []
+  VendorPrefixes:
+    enabled: true
+    identifier_list: bourbon
+    include: []
+    exclude: []
+  ZeroUnit:
+    enabled: true
+    severity: warning
+  Compass::PropertyWithMixin:
+    enabled: false

--- a/.scss-style.yml
+++ b/.scss-style.yml
@@ -6,7 +6,7 @@ linters:
     space_after_bang: false
   BorderZero:
     enabled: false
-    convention: zero
+    convention: none
   ColorKeyword:
     enabled: true
     severity: warning
@@ -17,20 +17,17 @@ linters:
   DebugStatement:
     enabled: true
   DeclarationOrder:
-    enabled: true
+    enabled: false
   DuplicateProperty:
     enabled: true
   ElsePlacement:
-    enabled: true
-    style: same_line
+    enabled: false
   EmptyLineBetweenBlocks:
-    enabled: true
-    ignore_single_line_blocks: true
+    enabled: false
   EmptyRule:
     enabled: true
   FinalNewline:
-    enabled: true
-    present: true
+    enabled: false
   HexLength:
     enabled: false
     style: short
@@ -40,32 +37,26 @@ linters:
   HexValidation:
     enabled: true
   IdSelector:
-    enabled: true
+    enabled: false
   ImportantRule:
-    enabled: true
+    enabled: false
   ImportPath:
-    enabled: true
-    leading_underscore: false
-    filename_extension: false
+    enabled: false
   Indentation:
     enabled: true
-    allow_non_nested_indentation: false
+    allow_non_nested_indentation: true
     character: space
     width: 2
   LeadingZero:
-    enabled: true
+    enabled: false
     style: include_zero
   MergeableSelector:
     enabled: true
     force_nesting: true
   NameFormat:
-    enabled: true
-    allow_leading_underscore: true
-    convention: hyphenated_lowercase
+    enabled: false
   NestingDepth:
-    enabled: true
-    max_depth: 4
-    severity: warning
+    enabled: false
   PlaceholderInExtend:
     enabled: false
   PropertyCount:
@@ -73,10 +64,7 @@ linters:
     include_nested: false
     max_properties: 10
   PropertySortOrder:
-    enabled: true
-    ignore_unspecified: false
-    severity: warning
-    separate_groups: false
+    enabled: false
   PropertySpelling:
     enabled: true
     extra_properties: []
@@ -87,12 +75,11 @@ linters:
     allow_element_with_id: false
     severity: warning
   SelectorDepth:
-    enabled: true
+    enabled: false
     max_depth: 2
     severity: warning
   SelectorFormat:
-    enabled: true
-    convention: hyphenated_lowercase
+    enabled: false
   Shorthand:
     enabled: true
     severity: warning
@@ -116,18 +103,17 @@ linters:
     enabled: true
     spaces: 0
   StringQuotes:
-    enabled: true
-    style: double_quotes
+    enabled: false
   TrailingSemicolon:
     enabled: true
   TrailingZero:
     enabled: false
   UnnecessaryMantissa:
-    enabled: true
+    enabled: false
   UnnecessaryParentReference:
-    enabled: true
+    enabled: false
   UrlFormat:
-    enabled: true
+    enabled: false
   UrlQuotes:
     enabled: true
   VariableForProperty:


### PR DESCRIPTION
# The following scss linting rules will now be enforced via hound:

For a more complete listing see: 
[Linting Options](https://github.com/causes/scss-lint/blob/master/lib/scss_lint/linter/README.md#urlquotes)

## Bang Format
Reports when you use improper spacing around ! (the "bang") in !important and !default declarations.

## Color Keyword
Prefer hexadecimal color codes over color keywords.

## Color Variable
Prefer color literals (keywords or hexadecimal codes) to be used only in variable declarations. They should be referred to via variables everywhere else.

## Comment
Prefer `//` comments over `/* ... */`.

## Debug Statement
Reports @debug statements

## Duplicate Property
Reports when you define the same property twice in a single rule set.

## Empty Rule
Reports when you have an empty rule set.

## Hex Notation
Checks if hexadecimal colors are written in lowercase.

## Hex Validation
Ensure hexadecimal colors are valid

## Indentation
Use two spaces per indentation level.

## Mergeable Selector
Reports when you define the same selector twice in a single sheet.

## Property Count
Limit the number of properties in a rule set.

## Property Spelling
Reports when you use an unknown CSS property

## Qualifying Element
Avoid qualifying elements in selectors
Bad:
```
div#thing {
  ...
}

ul.list {
  ...
}
```

## Shorthand
Prefer the shortest shorthand form possible for properties that support it.

## Single line per property
Properties within rule sets should each reside on their own line.

## Single line per Selector SpaceAfterComma SpaceAfterPropertyColon SpaceBetweenParens SpaceBeforeBrace SpaceAfterPropertyName
Conventional spacing

##   TrailingSemicolon

## UrlQuotes
URLs should always be enclosed within quotes.

##   VendorPrefixes:
Avoid vendor prefixes. That is, don't write them yourself.

##   ZeroUnit
Omit length units on zero values.

