### PR TITLE
hide linkedin social icon in footer

### DIFF
--- a/website-guts/assets/css/modules/footer.scss
+++ b/website-guts/assets/css/modules/footer.scss
@@ -44,6 +44,9 @@ footer {
     .social-links {
         li {
             display: inline-block;
+            &:nth-of-type(3) {
+              display: none;
+            }
         }
         a {
             background-size: 25px,25px;


### PR DESCRIPTION
This PR revert inappropriate color for linkedin social media icon in the grey footer https://github.com/optimizely/marketing-website/pull/937. 

![screen shot 2015-03-30 at 6 24 03 pm](https://cloud.githubusercontent.com/assets/4656726/6911192/33872758-d72b-11e4-954e-50877849fb8d.png)
