### PR TITLE
fix selector for leadform type and add fallback

### DIFF
--- a/website-guts/assets/js/utils/oform_globals.js
+++ b/website-guts/assets/js/utils/oform_globals.js
@@ -296,7 +296,7 @@
           utm_Medium__c: w.optly.mrkt.source.utm.medium,
           otm_Medium__c: w.optly.mrkt.source.otm.medium,
           Demo_Request_Monthly_Traffic__c: traffic.options[traffic.selectedIndex].value || '',
-          Inbound_Lead_Form_Type__c: d.querySelector('[name="inboundFormLeadType"]').value,
+          Inbound_Lead_Form_Type__c: d.querySelector('[name="Inbound_Lead_Form_Type__c"]').value || '',
           token: response.token
         }, {
           integrations: {


### PR DESCRIPTION
on all benefits pages
- /demo
- /enterprises
- /ecommerce

the `initContactForm` method was referencing a selector for `InboundLeadformType` that didn't exist

#### to test

submit form on any of these pages and put a breakpoint in the `w.optly.mrkt.utils.oform.initContactForm` method and check the object that is being passed to the `identify` method