### PR TITLE
remove tr helper from pricing modals

### DIFF
--- a/website-guts/templates/components/modals/downgrade_plan.hbs
+++ b/website-guts/templates/components/modals/downgrade_plan.hbs
@@ -9,6 +9,6 @@ TR_modal_title: "Are you sure you'd like to downgrade?"
 TR_primary_button_text: Change my plan
 TR_negative_button_text: Keep my existing plan
 ---
-<p>{{tr 'We\’ve made changes to our plans, and your existing plan has been retired. If you switch to our Starter plan now, you will not be able to switch back later.'}}</p>
+<p>We’ve made changes to our plans, and your existing plan has been retired. If you switch to our Starter plan now, you will not be able to switch back later.</p>
 
 <p><a href="//help.optimizely.com/hc/en-us/articles/200040055">{{{tr 'Learn more about these changes &raquo;'}}}</a></p>

--- a/website-guts/templates/components/modals/pricing_plan_signup_thank_you.hbs
+++ b/website-guts/templates/components/modals/pricing_plan_signup_thank_you.hbs
@@ -7,4 +7,4 @@ form_id: pricing-plan-signup-thank-you-form
 TR_modal_title: Thank you
 TR_negative_button_text: Sounds good
 ---
-              <p>{{{tr 'You\’re all set to start optimizing with our Starter plan. Visit the <a href="/dashboard">Dashboard</a> to set up your first experiment.'}}}</p>
+              <p>You’re all set to start optimizing with our Starter plan. Visit the <a href="/dashboard">Dashboard</a> to set up your first experiment.</p>


### PR DESCRIPTION
This PR addresses `tr` helper not removing backslash escape characters that is messing with translation strings and causing bad UX.

#### To Test

Go to /pricing and inspect 

- `id="pricing-plan-signup-thank-you-cont"`
- `id="downgrade-plan-cont"`

And make sure there are no remaining `\` characters.

![image 2](https://cloud.githubusercontent.com/assets/4656726/7092851/ab180800-df69-11e4-996e-864e5aa765c9.png)

