### PR TITLE
Change external yml reference in jobs layout

### DIFF
--- a/website-guts/templates/layouts/jobs.hbs
+++ b/website-guts/templates/layouts/jobs.hbs
@@ -7,11 +7,11 @@ layout_script: false
 
 <div id="main">
     <div id="lead-image">
-      {{#if jobs.page_intro}}
+      {{#if page_data.page_intro}}
         <div id="jobs-intro" class="a-center box">
-            <h2>{{jobs.page_intro.header}}</h2>
-            <p>{{jobs.page_intro.body}}</p>
-            <a id="view-all-jobs" class="button" href="#jobs-list">{{jobs.page_intro.button_text}}</a>
+            <h2>{{page_data.page_intro.header}}</h2>
+            <p>{{page_data.page_intro.body}}</p>
+            <a id="view-all-jobs" class="button" href="#jobs-list">{{page_data.page_intro.button_text}}</a>
         </div>
       {{/if}}
     </div>


### PR DESCRIPTION
In Assemble v6 migration messed referencing external yml data for jobs page.

check staging http://optimizely-marketing-site-staging.s3-website-us-east-1.amazonaws.com/dfoxpowell/fix-jobs-layout/jobs/