### PR TITLE
add default seo title suffix

### DIFF
--- a/grunt/assemble/plugins/smartling.js
+++ b/grunt/assemble/plugins/smartling.js
@@ -70,9 +70,16 @@ module.exports = function (assemble) {
     var filePathData = parseFilePath(file.path);
     var locale = filePathData.locale;
     var dataKey = filePathData.dataKey;
+    var seoTitle = file.data.TR_seo_title;
+    var seoTitleSuffix = ' - Optimizely';
+    var pagePhrases, parsedTranslations;
+
+    if(seoTitle && !~seoTitle.indexOf(seoTitleSuffix) && !~seoTitle.indexOf('Optimizely:')) {
+      file.data.TR_seo_title = seoTitle.trim() + seoTitleSuffix;
+    }
+
     //create lang dictionary from TR prefixes
-    var parsedTranslations = createTranslationDict(file, locale);
-    var pagePhrases;
+    parsedTranslations = createTranslationDict(file, locale);
 
     layoutData[locale] = layoutData[locale] || {};
 


### PR DESCRIPTION
This PR addresses https://optimizely.atlassian.net/browse/MKT-1696 requesting pages with a `TR_seo_title` key to have ` - Optimizely` appended to the value.

#### To Test

Find a page like /partners/solutions and inspect that the title in the browser tab got appended with ` - Optimizely`.

Now check a page with no `TR_seo_title` key such as the homepage and inspect that the title in the tab is `'Optimizely: Make every experience count'`