### PR TITLE
add plugin for seo title

### DIFF
--- a/grunt/assemble/index.js
+++ b/grunt/assemble/index.js
@@ -21,6 +21,7 @@ module.exports = function (grunt) {
     var mergeTranslatedData = require('./middleware/merge-translated-data');
     var resourceListType = require('./plugins/store-resource-list-types');
     var sendToSmartling = require('./plugins/smartling');
+    var addSeoTitle = require('./plugins/seo-title');
     var typeLoader = require('./loaders/type-loader');
     var push = require('assemble-push')(assemble);
     var buildInitialized = false;
@@ -289,6 +290,7 @@ module.exports = function (grunt) {
 
       return assemble.src(hbsPaths, { since: (assemble.get('lastRunTime')?new Date(assemble.get('lastRunTime')):null)})
         .pipe(extractLayoutContext(assemble))
+        .pipe(addSeoTitle())
         .pipe(sendToSmartling(assemble))
         .pipe(resourceListType(assemble))
         .on('error', function (err) {
@@ -307,6 +309,7 @@ module.exports = function (grunt) {
         return assemble.src([omSrc])
         .pipe(extractLayoutContext(assemble))
         .pipe(mergeLayoutContext())
+        .pipe(addSeoTitle())
         .pipe(ext())
         .pipe(assemble.dest(path.join(files.dest, ppcKey)))
         .on('data', function(file) {

--- a/grunt/assemble/plugins/seo-title.js
+++ b/grunt/assemble/plugins/seo-title.js
@@ -9,14 +9,14 @@ module.exports = function() {
    * @param {String} `str` dirname string.
    * @return {String} capitalized string.
    */
-   function cap(str) {
-     var firstChar = str.charAt(0);
-     if(isNaN(firstChar)) {
-       return firstChar.toUpperCase() + str.slice(1);
-     } else {
-       return str;
-     }
-   }
+  function cap(str) {
+    var firstChar = str.charAt(0);
+    if(isNaN(firstChar)) {
+      return firstChar.toUpperCase() + str.slice(1);
+    } else {
+      return str;
+    }
+  }
 
   /**
    * Parse a string for slashes. If they exist replace with spaces and capitalize first letter of each string.
@@ -24,17 +24,17 @@ module.exports = function() {
    * @param {String} `str` dirname string.
    * @return {String} capitalized string.
    */
-   function parseDirname(str) {
-     var split;
-     if(str.indexOf('-') !== -1) {
-       split = str.split('-');
-       return split.map(function(splitStr) {
-         return cap(splitStr);
-       }).join(' ');
-     } else {
-       return cap(str);
-     }
-   }
+  function parseDirname(str) {
+    var split;
+    if(str.indexOf('-') !== -1) {
+      split = str.split('-');
+      return split.map(function(splitStr) {
+        return cap(splitStr);
+      }).join(' ');
+    } else {
+      return cap(str);
+    }
+  }
 
   /**
    * Plugin to add SEO title
@@ -43,33 +43,32 @@ module.exports = function() {
    * - if visible_title exists use it plus a suffix
    *
    */
-   return through.obj(function (file, enc, cb) {
-     var possibleTitles = [
-       'TR_visible_title',
-       'title'
-     ];
-     var seoTitle = 'TR_seo_title';
-     var seoSuffix = ' - Optimizely';
-     var keys = Object.keys(file.data);
-     var defaultTitle = 'Optimizely: Make every experience count';
-     var altTitle, dirname;
+  return through.obj(function (file, enc, cb) {
+    var possibleTitles = [
+      'TR_visible_title',
+      'title'
+    ];
+    var seoTitle = 'TR_seo_title';
+    var seoSuffix = ' - Optimizely';
+    var keys = Object.keys(file.data);
+    var defaultTitle = 'Optimizely: Make every experience count';
+    var altTitle, dirname;
 
-     if(!~keys.indexOf(seoTitle)) {
-       altTitle = _.intersection(possibleTitles, keys)[0];
-       switch(altTitle) {
-         case possibleTitles[1]:
-           dirname = file.data.src.dirname;
-         dirname = dirname.substr(dirname.lastIndexOf('/') + 1);
-         file.data[seoTitle] = parseDirname(dirname) + seoSuffix;
-         break;
-         default:
-           file.data[seoTitle] = altTitle ? file.data[altTitle] + seoSuffix : defaultTitle;
-         break;
-       }
-     }
+    if(!~keys.indexOf(seoTitle)) {
+      altTitle = _.intersection(possibleTitles, keys)[0];
+      switch(altTitle) {
+        case possibleTitles[1]:
+          dirname = file.data.src.dirname;
+          dirname = dirname.substr(dirname.lastIndexOf('/') + 1);
+          file.data[seoTitle] = parseDirname(dirname) + seoSuffix;
+          break;
+        default:
+          file.data[seoTitle] = altTitle ? file.data[altTitle] + seoSuffix : defaultTitle;
+          break;
+      }
+    }
 
-     this.push(file);
-     cb();
-   });
+    this.push(file);
+    cb();
+  });
 };
-

--- a/grunt/assemble/plugins/seo-title.js
+++ b/grunt/assemble/plugins/seo-title.js
@@ -1,0 +1,75 @@
+var through = require('through2');
+var _ = require('lodash');
+
+module.exports = function() {
+
+  /**
+   * Capitalize first character of a string unless it is a number
+   *
+   * @param {String} `str` dirname string.
+   * @return {String} capitalized string.
+   */
+   function cap(str) {
+     var firstChar = str.charAt(0);
+     if(isNaN(firstChar)) {
+       return firstChar.toUpperCase() + str.slice(1);
+     } else {
+       return str;
+     }
+   }
+
+  /**
+   * Parse a string for slashes. If they exist replace with spaces and capitalize first letter of each string.
+   *
+   * @param {String} `str` dirname string.
+   * @return {String} capitalized string.
+   */
+   function parseDirname(str) {
+     var split;
+     if(str.indexOf('-') !== -1) {
+       split = str.split('-');
+       return split.map(function(splitStr) {
+         return cap(splitStr);
+       }).join(' ');
+     } else {
+       return cap(str);
+     }
+   }
+
+  /**
+   * Plugin to add SEO title
+   * - if SEO title exists use it
+   * - if title exists then use the capitalized dirname plus a suffix
+   * - if visible_title exists use it plus a suffix
+   *
+   */
+   return through.obj(function (file, enc, cb) {
+     var possibleTitles = [
+       'TR_visible_title',
+       'title'
+     ];
+     var seoTitle = 'TR_seo_title';
+     var seoSuffix = ' - Optimizely';
+     var keys = Object.keys(file.data);
+     var defaultTitle = 'Optimizely: Make every experience count';
+     var altTitle, dirname;
+
+     if(!~keys.indexOf(seoTitle)) {
+       altTitle = _.intersection(possibleTitles, keys)[0];
+       switch(altTitle) {
+         case possibleTitles[1]:
+           dirname = file.data.src.dirname;
+         dirname = dirname.substr(dirname.lastIndexOf('/') + 1);
+         file.data[seoTitle] = parseDirname(dirname) + seoSuffix;
+         break;
+         default:
+           file.data[seoTitle] = altTitle ? file.data[altTitle] + seoSuffix : defaultTitle;
+         break;
+       }
+     }
+
+     this.push(file);
+     cb();
+   });
+};
+

--- a/grunt/assemble/plugins/smartling.js
+++ b/grunt/assemble/plugins/smartling.js
@@ -70,13 +70,7 @@ module.exports = function (assemble) {
     var filePathData = parseFilePath(file.path);
     var locale = filePathData.locale;
     var dataKey = filePathData.dataKey;
-    var seoTitle = file.data.TR_seo_title;
-    var seoTitleSuffix = ' - Optimizely';
     var pagePhrases, parsedTranslations;
-
-    if(seoTitle && !~seoTitle.indexOf(seoTitleSuffix) && !~seoTitle.indexOf('Optimizely:')) {
-      file.data.TR_seo_title = seoTitle.trim() + seoTitleSuffix;
-    }
 
     //create lang dictionary from TR prefixes
     parsedTranslations = createTranslationDict(file, locale);


### PR DESCRIPTION
Reverts https://github.com/optimizely/marketing-website/pull/1018 to account for new logic in https://optimizely.atlassian.net/browse/MKT-1696

#### To Test

run `grunt server` 

check that pages with no `TR_seo_title` have in their tab

- if `TR_visible_title` is present, this will be concated with `- Optimizely`
- if `title` is present (partners pages) the dirname is being used, striped of slashes, capitalized, and concated with `- Optimizely`