### PR TITLE
Adding TR_seo_title to Opticon homepage

### DIFF
--- a/grunt/assemble/plugins/seo-title.js
+++ b/grunt/assemble/plugins/seo-title.js
@@ -48,13 +48,13 @@ module.exports = function() {
       'TR_visible_title',
       'title'
     ];
-    var seoTitle = 'TR_seo_title';
+    var seoTitle = [ 'TR_seo_title', 'seo_title' ];
     var seoSuffix = ' - Optimizely';
     var keys = Object.keys(file.data);
     var defaultTitle = 'Optimizely: Make every experience count';
     var altTitle, dirname;
 
-    if(!~keys.indexOf(seoTitle)) {
+    if(!_.union(keys, seoTitle).length) {
       altTitle = _.intersection(possibleTitles, keys)[0];
       switch(altTitle) {
         case possibleTitles[1]:

--- a/website/opticon/index.hbs
+++ b/website/opticon/index.hbs
@@ -1,6 +1,6 @@
 ---
 layout: opticon
-seo_title: Opticon
+TR_seo_title: "Opticon: Experience Optimization Conference"
 no_container: true
 no_header: true
 no_footer: true

--- a/website/opticon/index.hbs
+++ b/website/opticon/index.hbs
@@ -1,6 +1,6 @@
 ---
 layout: opticon
-TR_seo_title: "Opticon: Experience Optimization Conference"
+seo_title: "Opticon: Experience Optimization Conference"
 no_container: true
 no_header: true
 no_footer: true


### PR DESCRIPTION
Opticon is showing up as "OptiCon" in the Google search results. Fixing this by explicitly setting a title via TR_seo_title.