### PR TITLE
remove path.join from custom sass function

### DIFF
--- a/grunt/sass.js
+++ b/grunt/sass.js
@@ -13,7 +13,7 @@ module.exports = function(grunt){
           var imageUrl = grunt.config.get('imageUrl');
           var fileName = filename.getValue();
 
-          var imagePath = 'url("' + path.join(imageUrl, fileName) + '")';
+          var imagePath = 'url("' + imageUrl + '/' + fileName + '")';
           return new sass.types.String(imagePath);
         }
       }


### PR DESCRIPTION
`path.join` was breaking production paths because it was removing one of the slashes from double forwardslash asset path