### PR TITLE
Add og image to wrapper

### DIFF
--- a/website-guts/templates/layouts/wrapper.hbs
+++ b/website-guts/templates/layouts/wrapper.hbs
@@ -47,6 +47,7 @@ layout_modals:
         {{!-- Open Graph meta tags --}}
         <meta property="og:title" content="Optimizely: {{#if this.og_title}}{{this.og_title}}{{else}}Make every experience count{{/if}}">
         <meta property="og:description" content="{{#if this.og_description}}{{this.og_description}}{{else}}Deliver your best customer experiences at every touchpoint on the web and mobile apps.{{/if}}">
+        <meta property="og:image" content="//d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/global/optly_social_share.png">
         <!-- Place favicon.ico and apple-touch-icon(s) in the root directory -->
         {{#if environmentVariables.production}}
         <script>


### PR DESCRIPTION
This PR adds the og_image tag. Currently when posting to linkedin, a starbucks image appears as the image. Now an Optimizely image will appear.

To test: go to linkedin and click share a post. Paste in the staging url and verify the image being pulled in is the following:
https://s3.amazonaws.com/cloud_cannon_production/optimizely-marketer-assets.cloudvent.net/raw/global/optly_social_share.png?AWSAccessKeyId=AKIAIJL2YOFJV3LTZJDQ&Expires=1430849680&Signature=BTL7OJieev%2FZP4LeeDgWXCPSNO4%3D