### PR TITLE
Move down logo on resources page

### DIFF
--- a/website-guts/assets/css/pages/resources-page.scss
+++ b/website-guts/assets/css/pages/resources-page.scss
@@ -13,10 +13,6 @@ body.resources-page {
     width: 100%;
   }
 
-  .logo-cont {
-    height: 79px;
-  }
-
   .container {
     position: relative;
     &.header-cont {


### PR DESCRIPTION
The logo positioning is off on desktop.

I still need to fix it on mobile.