### PR TITLE
fix custom seo title

### DIFF
--- a/grunt/assemble/index.js
+++ b/grunt/assemble/index.js
@@ -290,7 +290,7 @@ module.exports = function (grunt) {
 
       return assemble.src(hbsPaths, { since: (assemble.get('lastRunTime')?new Date(assemble.get('lastRunTime')):null)})
         .pipe(extractLayoutContext(assemble))
-        .pipe(addSeoTitle())
+        .pipe(addSeoTitle(assemble))
         .pipe(sendToSmartling(assemble))
         .pipe(resourceListType(assemble))
         .on('error', function (err) {
@@ -309,7 +309,7 @@ module.exports = function (grunt) {
         return assemble.src([omSrc])
         .pipe(extractLayoutContext(assemble))
         .pipe(mergeLayoutContext())
-        .pipe(addSeoTitle())
+        .pipe(addSeoTitle(assemble))
         .pipe(ext())
         .pipe(assemble.dest(path.join(files.dest, ppcKey)))
         .on('data', function(file) {

--- a/grunt/assemble/plugins/seo-title.js
+++ b/grunt/assemble/plugins/seo-title.js
@@ -1,7 +1,8 @@
 var through = require('through2');
 var _ = require('lodash');
 
-module.exports = function() {
+module.exports = function(assemble) {
+  var parseFilePath = require('../utils/parse-file-path')(assemble);
 
   /**
    * Capitalize first character of a string unless it is a number
@@ -44,6 +45,8 @@ module.exports = function() {
    *
    */
   return through.obj(function (file, enc, cb) {
+    var fpData = parseFilePath(file.path);
+    var addSeoTitle = fpData.isRoot || fpData.isSubfolder;
     var possibleTitles = [
       'TR_visible_title',
       'title'
@@ -54,18 +57,22 @@ module.exports = function() {
     var defaultTitle = 'Optimizely: Make every experience count';
     var altTitle, dirname;
 
-    if(!_.union(keys, seoTitle).length) {
-      altTitle = _.intersection(possibleTitles, keys)[0];
-      switch(altTitle) {
-        case possibleTitles[1]:
-          dirname = file.data.src.dirname;
-          dirname = dirname.substr(dirname.lastIndexOf('/') + 1);
-          file.data[seoTitle] = parseDirname(dirname) + seoSuffix;
-          break;
-        default:
-          file.data[seoTitle] = altTitle ? file.data[altTitle] + seoSuffix : defaultTitle;
-          break;
+    if(addSeoTitle) {
+
+      if(!_.intersection(keys, seoTitle).length) {
+        altTitle = _.intersection(possibleTitles, keys)[0];
+        switch(altTitle) {
+          case possibleTitles[1]:
+            dirname = file.data.src.dirname;
+            dirname = dirname.substr(dirname.lastIndexOf('/') + 1);
+            file.data.TR_seo_title = parseDirname(dirname) + seoSuffix;
+            break;
+          default:
+            file.data.TR_seo_title = altTitle ? file.data[altTitle] + seoSuffix : defaultTitle;
+            break;
+        }
       }
+
     }
 
     this.push(file);


### PR DESCRIPTION
I made a mistake in https://github.com/optimizely/marketing-website/pull/1057 and accidentally reverted the ability to add a custom SEO default title.

## To Test

go to https://www.optimizelystaging.com/dfoxpowell/fix-seo-title/partners/solutions and click on individual partners page. Seo title in the browser tab should correspond to the filename