### PR TITLE
add relative path to favicon

### DIFF
--- a/grunt/filerev.js
+++ b/grunt/filerev.js
@@ -1,5 +1,5 @@
 module.exports = {
   assets: {
-    src: ['<%= config.dist %>/assets/**/*.{js,css,png,jpg,jpeg,gif}', '!<%= config.dist %>/assets/fonts/**']
+    src: ['<%= config.dist %>/assets/**/*.{js,css,png,jpg,jpeg,gif,ico}', '!<%= config.dist %>/assets/fonts/**']
   }
 };

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "grunt-s3": "0.2.0-alpha.3",
     "grunt-sass": "git+ssh://git@github.com/sindresorhus/grunt-sass.git#3f48c971cf1bcdcec67f47dbf439942639104db8",
     "grunt-text-replace": "0.3.12",
-    "grunt-userevvd": "0.1.4",
+    "grunt-userevvd": "0.1.5",
     "gulp-extname": "0.2.0",
     "handlebars": "3.0.0",
     "l10n-tools": "git+ssh://git@github.com/optimizely/l10n-tools.git",

--- a/website-guts/templates/layouts/wrapper.hbs
+++ b/website-guts/templates/layouts/wrapper.hbs
@@ -48,7 +48,7 @@ layout_modals:
         <meta property="og:title" content="Optimizely: {{#if this.og_title}}{{this.og_title}}{{else}}Make every experience count{{/if}}">
         <meta property="og:description" content="{{#if this.og_description}}{{this.og_description}}{{else}}Deliver your best customer experiences at every touchpoint on the web and mobile apps.{{/if}}">
         <meta property="og:image" content="https://d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/global/optly_social_share.png">
-        <!-- Place favicon.ico and apple-touch-icon(s) in the root directory -->
+        <link rel="shortcut icon" href="{{assetsDir}}/img/favicon.ico">
         {{#if environmentVariables.production}}
         <script>
         (function(d,b,a,s,e) {


### PR DESCRIPTION
This is in response to JIRA issue https://optimizely.atlassian.net/browse/MKT-1693

Now we are sourcing the favicon from a path rather than relying on it being in the root of the website. 

In production path should be https://du7782fucwe1l.cloudfront.net/img/favicon.ico

##  To test

- check in staging if favicon works
- locally run `grunt build` and check in one of the html templates `<head>` that favicon link is correct ` <link rel="shortcut icon" href="//du7782fucwe1l.cloudfront.net/img/favicon.ico/img/favicon.ico">`
