### PR TITLE
bump grunt sass to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "grunt-gitinfo": "0.1.6",
     "grunt-modernizr": "0.6.0",
     "grunt-s3": "0.2.0-alpha.3",
-    "grunt-sass": "git+ssh://git@github.com/sindresorhus/grunt-sass.git#3f48c971cf1bcdcec67f47dbf439942639104db8",
+    "grunt-sass": "1.0.0",
     "grunt-text-replace": "0.3.12",
     "grunt-userevvd": "0.1.5",
     "gulp-extname": "0.2.0",


### PR DESCRIPTION
- stop pulling grunt sass from GitHub directly