### PR TITLE
Switching Blog Link to HTTPS

### DIFF
--- a/website-guts/templates/layouts/faq.hbs
+++ b/website-guts/templates/layouts/faq.hbs
@@ -20,7 +20,7 @@ TR_faq_navigation:
  url: "http://developers.optimizely.com"
 -
  TR_text: "Blog"
- url: "http://blog.optimizely.com"
+ url: "https://blog.optimizely.com"
  swap_id: "faq-subnav-blog"
 ---
 <div id="main">

--- a/website-guts/templates/layouts/wrapper.hbs
+++ b/website-guts/templates/layouts/wrapper.hbs
@@ -153,7 +153,7 @@ layout_modals:
                                           <li><a href="http://certification.optimizely.com">{{tr 'Certification'}}</a></li>
                                           <li><a href="{{linkPath}}/resources/sample-size-calculator/">{{tr 'Sample Size Calculator'}}</a></li>
                                           <li><a href="{{linkPath}}/resources/">{{tr 'Content Library'}}</a></li>
-                                          <li id="SL-link-blog" class="SL_swap"><a href="http://blog.optimizely.com">{{tr 'Blog'}}</a></li>
+                                          <li id="SL-link-blog" class="SL_swap"><a href="https://blog.optimizely.com">{{tr 'Blog'}}</a></li>
                                         </ul>
                                     </li>
                                     <li class="last"><a href="{{linkPath}}/jobs/">{{tr 'Jobs'}}</a></li>
@@ -228,7 +228,7 @@ layout_modals:
                                             <li><a href="http://developers.optimizely.com">{{tr 'Developer Documentation'}}</a></li>
                                             <li><a href="{{linkPath}}/resources/sample-size-calculator/">{{tr 'Sample Size Calculator'}}</a></li>
                                             <li><a href="{{linkPath}}/resources/">{{tr 'Content Library'}}</a></li>
-                                            <li id="SL-link-blog" class="SL_swap"><a href="http://blog.optimizely.com">{{tr 'Blog'}}</a></li>
+                                            <li id="SL-link-blog" class="SL_swap"><a href="https://blog.optimizely.com">{{tr 'Blog'}}</a></li>
                                           </ul>
                                         </li>
                                         <li id="footer-nav-about" class="columns two">

--- a/website-guts/templates/om/layouts/wrapper.hbs
+++ b/website-guts/templates/om/layouts/wrapper.hbs
@@ -139,7 +139,7 @@
                                             <li><a href="http://developers.optimizely.com">Developer Documentation</a></li>
                                             <li><a href="{{linkPath}}/resources/sample-size-calculator/">Sample Size Calculator</a></li>
                                             <li><a href="{{linkPath}}/resources/">Content Library</a></li>
-                                            <li id="SL-link-blog" class="SL_swap"><a href="http://blog.optimizely.com">Blog</a></li>
+                                            <li id="SL-link-blog" class="SL_swap"><a href="https://blog.optimizely.com">Blog</a></li>
                                           </ul>
                                         </li>
                                         <li id="footer-nav-about" class="columns two">

--- a/website/nonprofits/index.hbs
+++ b/website/nonprofits/index.hbs
@@ -42,7 +42,7 @@ page_script: non-profits.js
         </div>
         <p>{{text}}</p>
         <div class="btn-cont">
-          <a href="http://blog.optimizely.com/2013/11/21/ab-testing-technology-global-relief-efforts-typhoon-haiyan/" target="_blank">{{button_text}}</a>
+          <a href="https://blog.optimizely.com/2013/11/21/ab-testing-technology-global-relief-efforts-typhoon-haiyan/" target="_blank">{{button_text}}</a>
           <span class="caret">&rsaquo;<span>
         </div>
       </div>

--- a/website/press/press.yml
+++ b/website/press/press.yml
@@ -22,14 +22,14 @@ investors:
   TR_header: "Investors"
 blog:
   TR_header: "Optimizely Blog"
-  link: "http://blog.optimizely.com/"
+  link: "https://blog.optimizely.com/"
   TR_btn_text: "Click here"
   TR_text: "to read the latest articles on our blog."
 follow_the_latest:
   TR_header: "Follow the latest from Optimizely:"
   TR_items:
   -
-    link: "http://blog.optimizely.com"
+    link: "https://blog.optimizely.com"
     TR_title: "Optimizely Blog: Conversion Rate Optimism"
     TR_text: "Optimizely Blog"
     swap_id: "press-footer-blog"

--- a/website/resources/resources-list/ab_advantage/index.hbs
+++ b/website/resources/resources-list/ab_advantage/index.hbs
@@ -3,7 +3,7 @@ TR_title: "By the Numbers: How A/B Testing Helps your Business"
 resources: true
 TR_type: "Infographic"
 photo: "//d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/resources/ab_advantage.png"
-url: "http://blog.optimizely.com/2014/01/08/ab-testing-advantage-infographic/"
+url: "https://blog.optimizely.com/2014/01/08/ab-testing-advantage-infographic/"
 priority: 70
 ---
 <div></div>

--- a/website/resources/resources-list/ab_testing_goes_mobile/index.hbs
+++ b/website/resources/resources-list/ab_testing_goes_mobile/index.hbs
@@ -3,7 +3,7 @@ TR_title: "The Optimized App: A/B Testing Goes Mobile"
 resources: true
 TR_type: "Infographic"
 photo: "//d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/resources/ab_testing_goes_mobile.png"
-url: "http://blog.optimizely.com/2014/05/09/the-optimized-app-ab-testing-goes-mobile/ "
+url: "https://blog.optimizely.com/2014/05/09/the-optimized-app-ab-testing-goes-mobile/ "
 priority: 66
 ---
 <div></div>

--- a/website/resources/resources-list/countdown_to_christmas/index.hbs
+++ b/website/resources/resources-list/countdown_to_christmas/index.hbs
@@ -3,7 +3,7 @@ TR_title: "By the Numbers: How Online Retailers Prepare for Christmas"
 resources: true
 TR_type: "Infographic"
 photo: "//d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/resources/countdown_to_christmas.png"
-url: "http://blog.optimizely.com/2013/07/25/online-retailers-countdown-to-christmas/"
+url: "https://blog.optimizely.com/2013/07/25/online-retailers-countdown-to-christmas/"
 priority: 26
 ---
 <div></div>

--- a/website/resources/resources-list/testing_team_structures/index.hbs
+++ b/website/resources/resources-list/testing_team_structures/index.hbs
@@ -3,7 +3,7 @@ TR_title: "Testing Team Structures: Which One Are You?"
 resources: true
 TR_type: "Infographic"
 photo: "//d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/resources/testing_team_structures.png"
-url: "http://blog.optimizely.com/2014/05/22/take-the-quiz-which-testing-team-are-you/"
+url: "https://blog.optimizely.com/2014/05/22/take-the-quiz-which-testing-team-are-you/"
 priority: 36
 ---
 <div></div>

--- a/website/statistics/statistics_data.yml
+++ b/website/statistics/statistics_data.yml
@@ -8,11 +8,11 @@ lets_talk:
   TR_subtitle: "Data has changed<br>Statistics should too"
   img: "//d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/statistics/analog-01.svg"
   MD_text: |
-    <p class="SL_swap" id="statsengine-letstalktext">Traditional statistics were developed over 100 years ago, for an offline world. These methods are no longer up to the task of helping businesses make decisions with real-time data. If you look at results in real time, as most optimization platforms allow you to do, you’ll see winning results where no winner actually exists. In fact, your error rate can skyrocket to <a href="http://blog.optimizely.com/2015/01/20/statistics-for-the-internet-age-the-story-behind-optimizelys-new-stats-engine/">over 30%</a> if you don't take precautions.</p>
+    <p class="SL_swap" id="statsengine-letstalktext">Traditional statistics were developed over 100 years ago, for an offline world. These methods are no longer up to the task of helping businesses make decisions with real-time data. If you look at results in real time, as most optimization platforms allow you to do, you’ll see winning results where no winner actually exists. In fact, your error rate can skyrocket to <a href="https://blog.optimizely.com/2015/01/20/statistics-for-the-internet-age-the-story-behind-optimizelys-new-stats-engine/">over 30%</a> if you don't take precautions.</p>
 
     Without taking precautions, like setting a sample size and committing to a minimum detectable effect in advance, you could make changes to your website or product that at best, have no impact, and at worst, could be hurting your bottom line.
   TR_cta_text: "Read the blog"
-  cta_link: "http://blog.optimizely.com/2015/01/20/statistics-for-the-internet-age-the-story-behind-optimizelys-new-stats-engine/"
+  cta_link: "https://blog.optimizely.com/2015/01/20/statistics-for-the-internet-age-the-story-behind-optimizelys-new-stats-engine/"
 better_way:
   TR_title: "THERE'S A BETTER WAY"
   TR_subtitle: "We believe statistics<br>should work the way you do"
@@ -51,7 +51,7 @@ compare:
   TR_footnote: "* We simulated millions of A/A tests under both frameworks and calculated error rate by determining the percentage of experiments that declared a winning or losing variation given a continuous monitoring policy. (1000+ visitors)"
   TR_cta_title: "Interested in how Stats Engine affects your results?"
   TR_cta_text: "Learn more"
-  cta_link: "http://blog.optimizely.com/2015/01/20/statistics-for-the-internet-age-the-story-behind-optimizelys-new-stats-engine/"
+  cta_link: "https://blog.optimizely.com/2015/01/20/statistics-for-the-internet-age-the-story-behind-optimizelys-new-stats-engine/"
 worry:
   TR_title: "Statistics has never been easier"
   TR_panels:


### PR DESCRIPTION
The blog has now moved from HTTP to HTTPS, updating the links in the header & footer to reference the new HTTPS url.