### PR TITLE
Update trulia logo on opticon homepage

### DIFF
--- a/website-guts/assets/css/pages/opticon-homepage.scss
+++ b/website-guts/assets/css/pages/opticon-homepage.scss
@@ -64,12 +64,9 @@ body.opticon-homepage {
     background-position: center;
     margin: 35px auto;
   }
-  .trulia {
-    background-position: 50% -406px;
-    background-size: 146px;
-  }
   .cbs { background-position: 50% -60px; }
-  .microsoft { background-size: contain; }
+  .trulia,
+  .microsoft,
   .marketo { background-size: contain; }
   .atlassian {
     background-size: contain;

--- a/website/opticon/global_opticon_data.yml
+++ b/website/opticon/global_opticon_data.yml
@@ -55,7 +55,7 @@ speaker_section:
       image: "//d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/microsoft_gray.svg"
       class: "microsoft"
     -
-      image: "//d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/customer-logos/sprite-1.png"
+      image: "//d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/opticon/speaker_companies/trulia_logo greyscale.svg"
       class: "trulia"
     -
       image: "//d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/customer-logos/sprite-1.png"


### PR DESCRIPTION
Trulia sent us an updated logo to be used on the Opticon homepage.