### PR TITLE
add locale tracking data to oform middleware

### DIFF
--- a/website-guts/assets/js/utils/no-global/get-language-key.js
+++ b/website-guts/assets/js/utils/no-global/get-language-key.js
@@ -1,0 +1,26 @@
+/**
+ * Utility function to append locale specific data to oForm payload object sent to /account/create endpoint
+ *
+ * @param {String} `data` string of form data encoded by oForm
+ * @return {String} encoded locale string to be appended to the oForm `data` string in the oForm middleware
+ */
+
+module.exports = function(data) {
+  var langKey;
+  var tld = window.location.hostname.split('.').pop();
+
+  if(window.optly.l10n && window.optly.l10n.locales) {
+    for(var key in window.optly.l10n.locales) {
+      if(key === tld) {
+        langKey = window.optly.l10n.locales[key];
+        break;
+      }
+    }
+
+    if(!langKey) {
+      langKey = 'us_EN';
+    }
+  }
+
+  return langKey ? window.encodeURI('&locale=' + langKey) : '';
+};

--- a/website-guts/assets/js/utils/no-global/get-language-key.js
+++ b/website-guts/assets/js/utils/no-global/get-language-key.js
@@ -6,8 +6,9 @@
  */
 
 module.exports = function() {
-  var langKey;
+  var DEFAULT_KEY = 'en_US';
   var tld = window.location.hostname.split('.').pop();
+  var langKey;
 
   if(window.optly.l10n && window.optly.l10n.locales) {
     for(var key in window.optly.l10n.locales) {
@@ -16,11 +17,11 @@ module.exports = function() {
         break;
       }
     }
-
-    if(!langKey) {
-      langKey = 'us_EN';
-    }
   }
 
-  return langKey ? window.encodeURI('&locale=' + langKey) : '';
+  if(!langKey) {
+    langKey = DEFAULT_KEY;
+  }
+
+  return window.encodeURI('&locale=' + langKey);
 };

--- a/website-guts/assets/js/utils/no-global/get-language-key.js
+++ b/website-guts/assets/js/utils/no-global/get-language-key.js
@@ -5,7 +5,7 @@
  * @return {String} encoded locale string to be appended to the oForm `data` string in the oForm middleware
  */
 
-module.exports = function(data) {
+module.exports = function() {
   var langKey;
   var tld = window.location.hostname.split('.').pop();
 

--- a/website-guts/assets/js/utils/oform_globals.js
+++ b/website-guts/assets/js/utils/oform_globals.js
@@ -1,5 +1,5 @@
 ;(function(){
-
+  var getLanguageKey = require('./no-global/get-language-key');
   var w, d;
 
   w = window;
@@ -21,7 +21,11 @@
   };
 
   w.optly.mrkt.Oform.defaultMiddleware = function(XHR, data){
-
+    //`this` is the oForm instance
+    var isCreateAccount = /\/account\/create/.test( $(this.selector).attr('action') );
+    if(isCreateAccount) {
+      data += getLanguageKey(data);
+    }
     XHR.withCredentials = true;
 
     return data;

--- a/website-guts/assets/js/utils/oform_globals.js
+++ b/website-guts/assets/js/utils/oform_globals.js
@@ -24,7 +24,7 @@
     //`this` is the oForm instance
     var isCreateAccount = /\/account\/create/.test( $(this.selector).attr('action') );
     if(isCreateAccount) {
-      data += getLanguageKey(data);
+      data += getLanguageKey();
     }
     XHR.withCredentials = true;
 

--- a/website-guts/helpers/stringifyJS.js
+++ b/website-guts/helpers/stringifyJS.js
@@ -1,0 +1,3 @@
+module.exports = function(key) {
+  return JSON.stringify(this.context[key]);
+};

--- a/website-guts/templates/layouts/wrapper.hbs
+++ b/website-guts/templates/layouts/wrapper.hbs
@@ -31,6 +31,8 @@ layout_modals:
             {{/is}}
             window.optly_q = [];
             window.optly = {};
+            window.optly.l10n = window.optly.l10n || {};
+            window.optly.l10n.locales = {{{stringifyJS 'locales'}}};
             window.analytics=window.analytics||[],window.analytics.methods=["identify","group","track","page","pageview","alias","ready","on","once","off","trackLink","trackForm","trackClick","trackSubmit"],window.analytics.factory=function(t){return function(){var a=Array.prototype.slice.call(arguments);return a.unshift(t),window.analytics.push(a),window.analytics}};for(var i=0;i<window.analytics.methods.length;i++){var key=window.analytics.methods[i];window.analytics[key]=window.analytics.factory(key)}window.analytics.load=function(t){if(!document.getElementById("analytics-js")){var a=document.createElement("script");a.type="text/javascript",a.id="analytics-js",a.async=!0,a.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.io/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n)}},window.analytics.SNIPPET_VERSION="2.0.9",
             window.analytics.load('{{environmentVariables.segmentProjectID}}');
             window.analytics.page();


### PR DESCRIPTION
@arthuracs @4vanger 
Adds temporary tracking of language key for `/account/create` based upon `ccTLD`.

- only works for requests made to `/account/create` (ie no `/account/free_trial_create`. @arthuracs let me know if this should be added as well but it would mean updating another endpoint.

## To Test
- go to any page that uses `/account/create` i.e. homepage, mobile page
- preserve the log in chrome network and inspect the request payload sent
- should see a `locale` key
- default is `us_EN`, unfortunately we cannot test this in staging for `ccTLD` unless you have some good ideas of how.

staging url: https://www.optimizelystaging.com/dfoxpowell/language-selection-cctld/

![screen shot 2015-05-13 at 10 07 47 am](https://cloud.githubusercontent.com/assets/4656726/7616262/f0476bd4-f957-11e4-8f1f-fdcc877e0a6d.png)
