### PR TITLE
add es5 shim for /free-trial

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "time-grunt": "0.3.2",
     "uglify-js": "2.4.15",
     "webpack": "^1.8.4",
-    "webpack-dev-server": "^1.8.0"
+    "webpack-dev-server": "^1.8.0",
+    "core-js": "^0.9.9"
   },
   "devDependencies": {
     "chai": "2.2.0",

--- a/website-guts/assets/js/layouts/trial-form.js
+++ b/website-guts/assets/js/layouts/trial-form.js
@@ -1,3 +1,4 @@
+require('core-js/es5');// jshint ignore:line
 w.optly.mrkt.inlineFormLabels();
 
 if(!w.optly.mrkt.isMobile()){


### PR DESCRIPTION
This is defensive coding after adding webpack to the marketing site. Adding the es-5 shim for older browser support on /free-trial

#### To Do
- run `ui-test` locally
- submit the form and check validation errors

@stewsmith please review