### PR TITLE
allow requests for user info to be made without cooking on cctld

### DIFF
--- a/website-guts/assets/js/head-scripts/user-state.js
+++ b/website-guts/assets/js/head-scripts/user-state.js
@@ -370,9 +370,17 @@ window.optly.mrkt.services.xhr = {
   },
 
   getLoginStatus: function(requestParams) {
+    var tld = window.location.hostname.split('.').pop();
+    var ccTLD = [
+      'es',
+      'fr',
+      'de',
+      'jp'
+    ];
+    var isCcTld = ccTLD.indexOf(tld) !== -1;
     var deferreds;
 
-    if ( !!this.readCookie('optimizely_signed_in') || /^www.optimizelystaging.com/.test(window.location.hostname) ) {
+    if ( !!this.readCookie('optimizely_signed_in') || /^www.optimizelystaging.com/.test(window.location.hostname) || isCcTld ) {
       deferreds = this.makeRequest(requestParams);
     } else {
       window.optly_q = window.optly.mrkt.Optly_Q();


### PR DESCRIPTION
This PR addresses https://optimizely.atlassian.net/browse/AI-386#add-comment since the app/www split.

Until we split to subfolders the `optimizely_signed_in` cookie is not being set on ccTLD. Therefore, logged in users on the marketing site will not have their info populated in the utility nav.

This fix is the same behavior that happens currently on staging. Requests will always be made for account info and experiment info. If the user is not logged in `/account/info` responds with an object containing null values, whereas the request for last five experiments fails.

*Note*: these changes should be removed after deployment of subfolders

## To Test

this is pretty much impossible to test until we get it into production. Test in staging https://www.optimizelystaging.com/dfoxpowell/hotfix-login-cctld/ just to make sure you can signin and create an account without errors, and when you return to the marketing site the utiility nav is populated with your user info.