### PR TITLE
Append query params on anchor tags for opticon

### DIFF
--- a/website-guts/assets/js/layouts/opticon.js
+++ b/website-guts/assets/js/layouts/opticon.js
@@ -5,7 +5,7 @@ var urlParams = window.optly.mrkt.utils.deparam(window.location.search);
 if (!$.isEmptyObject(urlParams)) {
   $('a').each(function(ind, item) {
     var $item = $(item);
-    if ($item.css('display') !== 'none') {
+    if ($item.is(':visible')) {
       var prevHref = $item.attr('href');
       var replacementHref = window.optly.mrkt.utils.param(prevHref, urlParams);
       $item.attr('href', replacementHref);

--- a/website-guts/assets/js/layouts/opticon.js
+++ b/website-guts/assets/js/layouts/opticon.js
@@ -1,6 +1,14 @@
 var urlParams = window.optly.mrkt.utils.deparam(window.location.search);
 
+// Append query params onto all anchor tags
+// so we can more accurately track ticket purchases
 if (!$.isEmptyObject(urlParams)) {
-  var replacementHref = window.optly.mrkt.utils.param('https://opticon2015.eventbrite.com/?ref=elink', urlParams);
-  $('.register-link').attr('href', replacementHref);
+  $('a').each(function(ind, item) {
+    var $item = $(item);
+    if ($item.css('display') !== 'none') {
+      var prevHref = $item.attr('href');
+      var replacementHref = window.optly.mrkt.utils.param(prevHref, urlParams);
+      $item.attr('href', replacementHref);
+    }
+  });
 }


### PR DESCRIPTION
Right now we're losing the query params if someone clicks around the Opticon site. This PR appends the query links to all anchor tags `href` attribute.

To test:
1. Visit staging`/opticon?test=true`
2. Click other navigation links and verify the param is still there.
3. Click on the register button and verify params are on eventbrite url