### PR TITLE
Remove default meta description

### DIFF
--- a/website-guts/templates/layouts/wrapper.hbs
+++ b/website-guts/templates/layouts/wrapper.hbs
@@ -45,7 +45,7 @@ layout_modals:
         {{#if environmentVariables.staging}}<meta name="robots" content="noindex">{{/if}}
         <title>{{#if this.seo_title}}{{this.seo_title}}{{else}}{{tr 'Optimizely: Make every experience count'}}{{/if}}</title>
         {{!-- Standard meta tags --}}
-        {{#if this.description}}<meta name="description" content="{{this.description}}">{{else}}{{/if}}
+        {{#if this.description}}<meta name="description" content="{{this.description}}">{{/if}}
         <meta name="keywords" content="AB test, split test, multivariate testing, conversion rate, experience optimization">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         {{!-- Open Graph meta tags --}}

--- a/website-guts/templates/layouts/wrapper.hbs
+++ b/website-guts/templates/layouts/wrapper.hbs
@@ -45,7 +45,9 @@ layout_modals:
         {{#if environmentVariables.staging}}<meta name="robots" content="noindex">{{/if}}
         <title>{{#if this.seo_title}}{{this.seo_title}}{{else}}{{tr 'Optimizely: Make every experience count'}}{{/if}}</title>
         {{!-- Standard meta tags --}}
-        <meta name="description" content="{{#if this.description}}{{this.description}}{{else}}Deliver your best customer experiences at every touchpoint on the web and mobile apps.{{/if}}">
+        {{#if this.description}}
+        <meta name="description" content="{{this.description}}">
+        {{else}}{{/if}}
         <meta name="keywords" content="AB test, split test, multivariate testing, conversion rate, experience optimization">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         {{!-- Open Graph meta tags --}}

--- a/website-guts/templates/layouts/wrapper.hbs
+++ b/website-guts/templates/layouts/wrapper.hbs
@@ -45,9 +45,7 @@ layout_modals:
         {{#if environmentVariables.staging}}<meta name="robots" content="noindex">{{/if}}
         <title>{{#if this.seo_title}}{{this.seo_title}}{{else}}{{tr 'Optimizely: Make every experience count'}}{{/if}}</title>
         {{!-- Standard meta tags --}}
-        {{#if this.description}}
-        <meta name="description" content="{{this.description}}">
-        {{else}}{{/if}}
+        {{#if this.description}}<meta name="description" content="{{this.description}}">{{else}}{{/if}}
         <meta name="keywords" content="AB test, split test, multivariate testing, conversion rate, experience optimization">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         {{!-- Open Graph meta tags --}}

--- a/website/index.hbs
+++ b/website/index.hbs
@@ -5,6 +5,7 @@ body_class:
 page_script: homepage.js
 layout_script: false
 layout_body_class: false
+TR_description: "Deliver your best customer experiences at every touchpoint on the web and mobile apps."
 meta_tags:
 - '<link rel="publisher" href="//plus.google.com/113842166556345533815"/>'
 - '<meta name="msvalidate.01" content="C1A3B92B884297B25A614BCE029150EC" />'


### PR DESCRIPTION
The meta description is used to tell Google what the page is about and is often displayed as the description in the search results.

If a custom description is set, then the page should include should display the meta description so that Google can show the optimized snippet.

However, if a custom description does not exist, then no meta description should be displayed so that Google can generate it's own description for the page.