### PR TITLE
Add developers account signup form

### DIFF
--- a/website-guts/assets/js/components/modal-devsignup.js
+++ b/website-guts/assets/js/components/modal-devsignup.js
@@ -1,0 +1,50 @@
+//TODO(peng-wen): Remove this component once the dev account signup logic is moved to the developers site
+var signupDialogHelperInst = window.optly.mrkt.form.createAccount({formId: 'dev-signup-form', dialogId: 'dev-signup-dialog'});
+
+var devSignupForm = new Oform({
+  selector: '#dev-signup-form',
+  customValidation: {
+    password1: function(elm) {
+      return signupDialogHelperInst.password1Validate(elm);
+    },
+    password2: function(elm) {
+      return signupDialogHelperInst.password2Validate(elm);
+    }
+  },
+  middleware: w.optly.mrkt.Oform.defaultMiddleware
+});
+
+devSignupForm.on('before', function() {
+  //set the hidden input value
+  signupDialogHelperInst.formElm.querySelector('[name="hidden"]').value = 'touched';
+  signupDialogHelperInst.processingAdd();
+  if(signupDialogHelperInst.characterMessageElm.classList.contains('oform-error-show')) {
+    signupDialogHelperInst.characterMessageElm.classList.remove('oform-error-show');
+  }
+  return true;
+})
+.on('validationerror', function(elm) {
+  w.optly.mrkt.Oform.validationError(elm);
+  signupDialogHelperInst.showOptionsError({error: 'DEFAULT'});
+  if(!signupDialogHelperInst.characterMessageElm.classList.contains('oform-error-show')) {
+    signupDialogHelperInst.characterMessageElm.classList.add('oform-error-show');
+  }
+})
+.on('error', function() {
+  signupDialogHelperInst.processingRemove({callee: 'error'});
+  signupDialogHelperInst.showOptionsError({error: 'UNEXPECTED'});
+  window.analytics.track('create account xhr error', {
+    category: 'account',
+    label: w.location.pathname
+  }, {
+    integrations: {
+      Marketo: false
+    }
+  });
+}.bind(signupDialogHelperInst))
+.on('load', signupDialogHelperInst.load.bind(signupDialogHelperInst))
+.on('done', function() {
+  if (document.body.classList.contains('oform-error')) {
+    signupDialogHelperInst.processingRemove({callee: 'done'});
+  }
+}.bind(signupDialogHelperInst));

--- a/website-guts/assets/js/pages/homepage.js
+++ b/website-guts/assets/js/pages/homepage.js
@@ -78,3 +78,10 @@ $('#get-started input:not([type="hidden"]), #signup-form input:not([type="hidden
     }
   }, 1000);
 });
+
+//TODO(peng-wen): Temporarily allowing signing up developer accounts here.
+//Move this to developers site once fixing the HTTPS issue
+var modal = w.optly.mrkt.utils.getURLParameter('modal');
+if (modal === 'devsignup') {
+  w.optly.mrkt.modal.open({ modalType: modal, track: false });
+}

--- a/website-guts/assets/js/pages/homepage.js
+++ b/website-guts/assets/js/pages/homepage.js
@@ -83,5 +83,5 @@ $('#get-started input:not([type="hidden"]), #signup-form input:not([type="hidden
 //Move this to developers site once fixing the HTTPS issue
 var modal = w.optly.mrkt.utils.getURLParameter('modal');
 if (modal === 'devsignup') {
-  w.optly.mrkt.modal.open({ modalType: modal  });
+  w.optly.mrkt.modal.open({ modalType: modal });
 }

--- a/website-guts/assets/js/pages/homepage.js
+++ b/website-guts/assets/js/pages/homepage.js
@@ -83,5 +83,5 @@ $('#get-started input:not([type="hidden"]), #signup-form input:not([type="hidden
 //Move this to developers site once fixing the HTTPS issue
 var modal = w.optly.mrkt.utils.getURLParameter('modal');
 if (modal === 'devsignup') {
-  w.optly.mrkt.modal.open({ modalType: modal, track: false });
+  w.optly.mrkt.modal.open({ modalType: modal });
 }

--- a/website-guts/assets/js/pages/homepage.js
+++ b/website-guts/assets/js/pages/homepage.js
@@ -83,5 +83,5 @@ $('#get-started input:not([type="hidden"]), #signup-form input:not([type="hidden
 //Move this to developers site once fixing the HTTPS issue
 var modal = w.optly.mrkt.utils.getURLParameter('modal');
 if (modal === 'devsignup') {
-  w.optly.mrkt.modal.open({ modalType: modal });
+  w.optly.mrkt.modal.open({ modalType: modal  });
 }

--- a/website-guts/templates/components/modals/dev_signup_modal.hbs
+++ b/website-guts/templates/components/modals/dev_signup_modal.hbs
@@ -7,7 +7,7 @@ form_id: dev-signup-form
 TR_modal_title: "Create a developer account"
 TR_modal_sub_header: "Get a free account with full access to Optimizely's APIs and SDKs."
 form_method: POST
-form_action: /account/create_dev_account
+form_action: /account/create
 TR_primary_button_text: Create account
 TR_negative_button_text: Cancel
 api_domain: true

--- a/website-guts/templates/components/modals/dev_signup_modal.hbs
+++ b/website-guts/templates/components/modals/dev_signup_modal.hbs
@@ -1,6 +1,6 @@
 ---
 layout: modal_wrapper
-wrapper_id: signup-dialog
+wrapper_id: dev-signup-dialog
 data_modal_id: devsignup
 data_modal_name: dev-sign-up
 form_id: dev-signup-form

--- a/website-guts/templates/components/modals/dev_signup_modal.hbs
+++ b/website-guts/templates/components/modals/dev_signup_modal.hbs
@@ -1,0 +1,17 @@
+---
+layout: modal_wrapper
+wrapper_id: signup-dialog
+data_modal_id: devsignup
+data_modal_name: dev-sign-up
+form_id: dev-signup-form
+TR_modal_title: "Create a developer account"
+TR_modal_sub_header: "Get a free account with full access to Optimizely's APIs and SDKs."
+form_method: POST
+form_action: /account/create_dev_account
+TR_primary_button_text: Create account
+TR_negative_button_text: Cancel
+api_domain: true
+initial_form_source: Create Account - Developers
+inbound_form_lead_type: Create Account - Developers
+---
+              {{> (l10nPartial 'signup_form')}}

--- a/website-guts/templates/layouts/wrapper.hbs
+++ b/website-guts/templates/layouts/wrapper.hbs
@@ -2,7 +2,6 @@
 layout_modals:
 - signin_modal
 - signup_modal
-- dev_signup_modal
 - create_experiment
 - reset_password
 - error_modal

--- a/website-guts/templates/layouts/wrapper.hbs
+++ b/website-guts/templates/layouts/wrapper.hbs
@@ -2,6 +2,7 @@
 layout_modals:
 - signin_modal
 - signup_modal
+- dev_signup_modal
 - create_experiment
 - reset_password
 - error_modal

--- a/website/index.hbs
+++ b/website/index.hbs
@@ -10,6 +10,8 @@ meta_tags:
 - '<link rel="publisher" href="//plus.google.com/113842166556345533815"/>'
 - '<meta name="msvalidate.01" content="C1A3B92B884297B25A614BCE029150EC" />'
 HTML_page_content: true
+modals:
+- dev_signup_modal
 ---
 <section id="cta">
   <a href="{{linkPath}}/opticon?aff=homepage_ad" class="opticon-ad"></a>


### PR DESCRIPTION
Create the developers account signup form at the marketing site for now since we encounter an HTTPS setup issue for the new developers site which prevents the site from sending CORS requests to our GAE app.

request review: @stewsmith @tscanlin 