### PR TITLE
TR_ on partners fix

### DIFF
--- a/website/partners/solutions/digitaslbi-hong-kong/index.hbs
+++ b/website/partners/solutions/digitaslbi-hong-kong/index.hbs
@@ -9,17 +9,17 @@ website_display: "www.digitaslbi.com/hk"
 kb_article: ""
 stars: 1
 TR_industry: "Executive Consulting, Strategic Consulting, Custom Implementation, Test Development, Execution, & Management"
-locations:
+TR_locations:
 - location:
     phone: "+852 2236 0330"
     email: "apac-optimisation@digitaslbi.com"
-    region: "Asia Pacific"
-    city: "Hong Kong"
-    state: "Hong Kong"
+    TR_region: "Asia Pacific"
+    TR_city: "Hong Kong"
+    TR_state: "Hong Kong"
     address1: "9/F South East Wing, Warwick House, Taikoo Place, 979 King's Road, Quarry Bay"
     address2: ""
     zip: ""
-    country: "Hong Kong"
+    TR_country: "Hong Kong"
 contact: ""
 languages:
 - "English"

--- a/website/partners/solutions/goldbach-interactive/index.hbs
+++ b/website/partners/solutions/goldbach-interactive/index.hbs
@@ -13,13 +13,13 @@ TR_locations:
 - location:
     phone: "+49 7531 89207-0"
     email: "info@goldbachinteractive.de"
-    region: "EMEA - Germany"
-    city: "Konstanz"
-    state: "Baden-Württemberg"
+    TR_region: "EMEA - Germany"
+    TR_city: "Konstanz"
+    TR_state: "Baden-Württemberg"
     address1: "Bleicherstraße 10"
     address2:
     zip: "78467"
-    country: "Germany"
+    TR_country: "Germany"
 contact:
 languages:
 - "German"

--- a/website/partners/solutions/hop-online/index.hbs
+++ b/website/partners/solutions/hop-online/index.hbs
@@ -9,17 +9,17 @@ website_display: "hop-online.com"
 kb_article:
 stars: 1
 TR_industry: "Executive Consulting, Strategic Consulting, Custom Implementation, Test Development, Execution, & Management"
-locations:
+TR_locations:
 - location:
     phone: "504-207-1971"
     email: "info@hop-online.com"
-    region: "North America- US Other"
-    city: "New Orleans"
-    state: "LA"
+    TR_region: "North America- US Other"
+    TR_city: "New Orleans"
+    TR_state: "LA"
     address1: "3637 Canal St."
     address2:
     zip: "70119"
-    country: "USA"
+    TR_country: "USA"
 contact:
 languages:
 - "English"

--- a/website/partners/solutions/mccann-connected/index.hbs
+++ b/website/partners/solutions/mccann-connected/index.hbs
@@ -9,17 +9,17 @@ website_display: "www.mccannmanchester.com/connected"
 kb_article:
 stars: 1
 TR_industry: "Executive Consulting, Strategic Consulting, Custom Implementation, Test Development, Execution, & Management"
-locations:
+TR_locations:
 - location:
     phone: "+44 162 582 2200"
     email: "new.business@mccann.com"
-    region: "EMEA - UK"
-    city: "Prestbury"
-    state: "Cheshire"
+    TR_region: "EMEA - UK"
+    TR_city: "Prestbury"
+    TR_state: "Cheshire"
     address1: "Bonis Hall"
     address2: "Bonis Hall Lane"
     zip: "SK10 4EF"
-    country: "United Kingdom"
+    TR_country: "United Kingdom"
 contact:
 languages:
 - "English"
@@ -27,7 +27,7 @@ languages:
 - "German"
 - "Italian"
 - "Spanish"
-tags:
+TR_tags:
 - "E-Commerce / Retail"
 - "Finance"
 - "Insurance"


### PR DESCRIPTION
Right now some of the partners are not sorting correctly. This PR fixes that by prefixing `locations`, `region`, `state`, `city`, and `country` with`TR_`

To test, go to production and sort by "EMEA - Germany". Notice goldbach-interactive is not there. Try the same thing on staging and notice goldbach-interactive is there.