### PR TITLE
Remove hardcoded references to optimizely.com

### DIFF
--- a/website/features-and-plans/global_features.yml
+++ b/website/features-and-plans/global_features.yml
@@ -116,9 +116,9 @@ enterprise_section:
   title: "Enterprise"
   subtitle: "Customized plans for your business."
   cta: "Talk to Us"
-  feature_cta: "Interested in seeing more? <a href='https://www.optimizely.com/feature-list'>See full feature list &raquo;</a>"
+  feature_cta: "Interested in seeing more? <a href='/feature-list'>See full feature list &raquo;</a>"
 
 starter_section:
   title: "Not ready for Enterprise?"
-  subtitle: "Get the <a href='https://www.optimizely.com/feature-list'>basics</a> with our free Starter Plan. No credit card required."
+  subtitle: "Get the <a href='/feature-list'>basics</a> with our free Starter Plan. No credit card required."
   cta: "Get Started"

--- a/website/partners/technology/join/join_data.yml
+++ b/website/partners/technology/join/join_data.yml
@@ -48,5 +48,5 @@ benefits:
 #   video_url: "//play.vidyard.com/Bf0qpT872TFpgGnJUqm0kA.html?v=3.1"
 join:
   TR_title: "Join the Optimizely Technology Partner Program"
-  TR_blurb:  "To learn more about the requirements and benefits of our partner program <a href='http://pages.optimizely.com/rs/361-GER-922/images/Optimizely Technology Partners.pdf'>click here</a>. To see a list of technology partners we work with today, <a href='https://www.optimizely.com/partners/technology/'>check out our partner directory</a>."
+  TR_blurb:  "To learn more about the requirements and benefits of our partner program <a href='http://pages.optimizely.com/rs/361-GER-922/images/Optimizely Technology Partners.pdf'>click here</a>. To see a list of technology partners we work with today, <a href='/partners/technology/'>check out our partner directory</a>."
   button_text: "Apply Now"

--- a/website/plans/global_faq_section.yml
+++ b/website/plans/global_faq_section.yml
@@ -13,7 +13,7 @@ TR_faqs:
     TR_answer: "As a current customer, you are grandfathered into the original plan you selected. You can continue to use this plan, or select a new plan if you feel Starter or Enterprise better meets your needs. You can find more answers in this <a href='https://help.optimizely.com/hc/en-us/articles/200040055'>FAQ</a>."
   -
     TR_question: "Does Optimizely offer nonprofit pricing?"
-    TR_answer: "Yes. Visit <a href='https://www.optimizely.com/nonprofits'>Optimizely for non-profits</a> for more information."
+    TR_answer: "Yes. Visit <a href='/nonprofits'>Optimizely for non-profits</a> for more information."
   -
     TR_question: "I have more questions. Where can I find answers?"
     TR_answer: "Check out our <a href='https://help.optimizely.com'>Knowledge Base</a> for questions about how Optimizely works on your website or mobile app. If you have questions about an enterprise plan, please get in touch by calling or filling out a form. We’ll get back to you!"

--- a/website/solutions/solutions.yml
+++ b/website/solutions/solutions.yml
@@ -6,7 +6,7 @@ products_section:
   products:
     -
       tab_title: "Testing"
-      blurb: "<p>Optimizely Testing is the most adopted A/B testing platform in the world, optimizing billions of experiences every month for customers across diverse industries including media, retail, travel, and technology.</p><p>Easy-to-use and robust <a href='https://www.optimizely.com/ab-testing/'>A/B</a>, <a href='https://www.optimizely.com/resources/multivariate-testing/'>multivariate</a>, and multi-page testing gives you everything you need to improve engagement and increase revenue across desktop, mobile web, and <a href='https://www.optimizely.com/mobile/'>mobile apps</a>.</p>"
+      blurb: "<p>Optimizely Testing is the most adopted A/B testing platform in the world, optimizing billions of experiences every month for customers across diverse industries including media, retail, travel, and technology.</p><p>Easy-to-use and robust <a href='/ab-testing/'>A/B</a>, <a href='/resources/multivariate-testing/'>multivariate</a>, and multi-page testing gives you everything you need to improve engagement and increase revenue across desktop, mobile web, and <a href='/mobile/'>mobile apps</a>.</p>"
       product_image: "//d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/solutions/product_illustrations/testing_final.svg"
     -
       tab_title: "Personalization"
@@ -14,11 +14,11 @@ products_section:
       product_image: "//d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/solutions/product_illustrations/personalization_final.svg"
     -
       tab_title: "Targeting"
-      blurb: "<p>Easily target the right audience for your tests and personalized experiences.  Build your own segments and audiences using our advanced targeting capabilities (geography, URL, browser, and more) and third-party <a href='https://www.optimizely.com/partners/technology/'>integrations</a>, or use your existing lists.</p><p>Optimizely makes it simple to combine the data that matters to your business to target the optimal audience.</p>"
+      blurb: "<p>Easily target the right audience for your tests and personalized experiences.  Build your own segments and audiences using our advanced targeting capabilities (geography, URL, browser, and more) and third-party <a href='/partners/technology/'>integrations</a>, or use your existing lists.</p><p>Optimizely makes it simple to combine the data that matters to your business to target the optimal audience.</p>"
       product_image: "//d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/solutions/product_illustrations/targeting_final.svg"
     -
       tab_title: "Analytics"
-      blurb: "<p>Real-time results accessed through dashboards and reporting enables you take action on your data quickly and reliably. Make decisions with confidence using the <a id='statslink' class='SL_swap' href='https://www.optimizely.com/statistics/'>Optimizely Stats Engine</a> – its always-valid results automatically adjust for the real world of multiple goals.</p><p>Optimizely also offers <a href='https://www.optimizely.com/partners/technology/'>integrations</a> with leading analytics providers, giving you full flexibility to evaluate the results in a way that works for your business.</p>"
+      blurb: "<p>Real-time results accessed through dashboards and reporting enables you take action on your data quickly and reliably. Make decisions with confidence using the <a href='/statistics/'>Optimizely Stats Engine</a> – its always-valid results automatically adjust for the real world of multiple goals.</p><p>Optimizely also offers <a href='/partners/technology/'>integrations</a> with leading analytics providers, giving you full flexibility to evaluate the results in a way that works for your business.</p>"
       product_image: "//d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/solutions/product_illustrations/analytics__final.svg"
     -
       tab_title: "Platform"


### PR DESCRIPTION
 to make sure links correctly resolve on international domains.

@stewsmith can you review? The references to www.optimizely.com jump visitors on international domains back to the English site. If we just make it a relative link, they'll stay on the international site. I fixed it in the places I could find, but please make sure to use relative links for any internal links.

@KarenLoughrey this should address the link issues you were seeing on https://www.optimizely.de/solutions/ and other international domains.