### PR TITLE
MKT-2075 -- Add swap tag to tech partners signup page

### DIFF
--- a/website/partners/technology/join/index.hbs
+++ b/website/partners/technology/join/index.hbs
@@ -59,7 +59,7 @@ og_description: ""
     <h2 class="panel-header">{{{title}}}</h2>
 
     {{#each items}}
-      <div class="split-cols clearfix">
+      <div class="split-cols clearfix {{#if this.swap}}SL_swap{{/if}}" {{#if this.id}}id="{{this.id}}"{{/if}}>
 
         <div>
           <img src="{{image}}">

--- a/website/partners/technology/join/join_data.yml
+++ b/website/partners/technology/join/join_data.yml
@@ -37,6 +37,8 @@ benefits:
       class: "amplify"
     -
       image: "https://d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/partners-become/illustration2.svg"
+      id: "JP_tech_join"
+      swap: true
       TR_title: "Collaborative Sales Enablement Approach"
       TR_blurb: "Get access to a dedicated partner manager, develop joint sales collateral and connect with Optimizely Account Executives."
       class: "grow"


### PR DESCRIPTION
Add a swap tag and id to /partners/technology/join so a section doesn't show up in japan.

https://optimizely.atlassian.net/browse/MKT-2075

To test: go to /partners/technology/join and inspect the last benefit. It should have a class of `SL_swap` and id of `JP_tech_join`

![screen shot 2015-06-26 at 1 52 17 pm](https://cloud.githubusercontent.com/assets/2864449/8387107/fed02c10-1c0a-11e5-8329-47d249a28ccd.png)
