### PR TITLE
Update robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
-Disallow:
+Disallow: /l/
 
 Sitemap: https://www.optimizely.com/sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
-Disallow: /l/
+Disallow:
 
-sitemap: https://www.optimizely.com/sitemap.xml
+Sitemap: https://www.optimizely.com/sitemap.xml


### PR DESCRIPTION
This PR firstly corrects the spelling of the Sitemap attribute and secondly allows indexing of all assets by disallowing nothing. Not sure why the `/l/` directory was being ignored before?

@stewsmith @dtothefp - do you know why we were ignoring the `/l/` directory before or what the `/l/` directory even is?