### PR TITLE
Add reporting to tab click on solutions

### DIFF
--- a/website-guts/assets/js/pages/solutions.js
+++ b/website-guts/assets/js/pages/solutions.js
@@ -18,6 +18,14 @@ if (!!urlProduct) {
 $productTabs.on('click', function() {
   var $this = $(this);
   var tabTitle = $this.attr('id');
+  w.analytics.track('solutions tab change', {
+    category: 'tab click',
+    label: tabTitle
+  }, {
+    integrations: {
+      Marketo: false
+    }
+  });
 
   $productTabs.removeClass('product-tab--active');
   $this.addClass('product-tab--active');


### PR DESCRIPTION
On /solutions when the user clicks on one of these:
![screen shot 2015-07-01 at 10 27 35 am](https://cloud.githubusercontent.com/assets/2864449/8456824/dfddee76-1fdb-11e5-97e9-c57228d5aafb.png)
we need to track it.

I've verified this is going through to segment:
![screen shot 2015-07-01 at 10 45 30 am](https://cloud.githubusercontent.com/assets/2864449/8457252/58a256b0-1fde-11e5-9f5c-5e09305e5379.png)
