### PR TITLE
Fix typo on contact thank you

### DIFF
--- a/website-guts/templates/partials/contact_form.hbs
+++ b/website-guts/templates/partials/contact_form.hbs
@@ -45,7 +45,7 @@ HTML_page_content: true
           <button class="button small" type="submit">Submit</button>
         </li>
         <li id="confirmation" class="success-show">
-          <p>Thanks for contacting us! We\'ll be in touch shortly!</p>
+          <p>Thanks for contacting us! We'll be in touch shortly!</p>
         </li>
       </ul>
       <input type="hidden" name="Inbound_Lead_Form_Type__c" value="{{this.inbound_form_lead_type}}">


### PR DESCRIPTION
"We'll be in touch shortly" typo:

![screen shot 2015-07-01 at 10 31 51 am](https://cloud.githubusercontent.com/assets/7796339/8460796/6cd450fe-1fdc-11e5-96e9-e1793113f345.png)
