### PR TITLE
Removed whitespace from sitemap.xml file.

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,6242 +2,6242 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
 	<url>
 		<loc>https://www.optimizely.com/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/about/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/statistics/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/statistics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/statistics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/statistics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/statistics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/statistics/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/statistics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/jobs/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/split-testing/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/split-testing/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/split-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/customers/customer-stories/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/resources/multivariate-testing/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-testing/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/privacy</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/pricing</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/pricing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/pricing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/pricing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/pricing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/pricing/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/pricing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/security/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/security/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/security/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/security/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/security/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/security/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/security/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/security/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/security/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/security/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/security/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/events/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/small-business/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/demo/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/demo/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/demo/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/demo/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/demo/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/demo/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/demo/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/demo/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/demo/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/demo/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/demo/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/ab-testing/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/mobile/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/privacy/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/faq/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/terms</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/resources/sample-size-calculator/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/sample-size-calculator/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/sample-size-calculator/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/press/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/resources/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/benefits/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/ecommerce/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/enterprises/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/contact/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/resources/live-demo-webinar/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/customers/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/opt_out/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/opt_out/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/opt_out/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/terms/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/publishers/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/about</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/events</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/jobs</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/resources/multivariate-test-vs-ab-test</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-test-vs-ab-test/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-test-vs-ab-test/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/press</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/contact</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/communities</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/communities/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/communities/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/communities/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/communities/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/communities/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/communities/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/communities/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/communities/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/communities/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/communities/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/ab-testing</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/resources/split-testing-tool</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/split-testing-tool/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/split-testing-tool/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/parsely</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/parsely/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/parsely/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/skymosity</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/skymosity/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/skymosity/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/qualaroo</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/qualaroo/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/qualaroo/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/sessioncam</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sessioncam/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sessioncam/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/segment</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/segment/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/segment/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/inspectlet</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/inspectlet/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/inspectlet/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/bluekai</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bluekai/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bluekai/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/tealium</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/tealium/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/tealium/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/freespee</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/freespee/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/freespee/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/episerver</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/episerver/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/episerver/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/delacon</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/delacon/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/delacon/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/google-analytics</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/google-analytics/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/google-analytics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/lotame</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lotame/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lotame/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/avanser</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/avanser/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/avanser/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/moat</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/moat/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/moat/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/ptengine</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/ptengine/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/ptengine/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/crazy-egg</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/crazy-egg/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/crazy-egg/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/dialogtech</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/dialogtech/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/dialogtech/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/demandbase</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/demandbase/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/demandbase/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/clicktale</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/clicktale/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/clicktale/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/bizible</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bizible/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bizible/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/comscore</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/comscore/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/comscore/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/signal</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/signal/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/signal/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/sitecatalyst</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sitecatalyst/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sitecatalyst/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/mixpanel</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/mixpanel/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/mixpanel/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/kissmetrics</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/kissmetrics/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/kissmetrics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/woopra</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/woopra/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/woopra/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/lytics</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lytics/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lytics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/at-internet</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/at-internet/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/at-internet/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/technology/krux</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/krux/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/krux/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/customers/customer-stories</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/customers</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/privacy/12/16/2013</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/12/16/2013/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/12/16/2013/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/nonprofits</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/nonprofits/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/nonprofits/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/resources</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/k60analytics</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/k60analytics/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/k60analytics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/divisadero</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/divisadero/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/divisadero/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/tiekinetix</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/tiekinetix/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/tiekinetix/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/eagency</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/eagency/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/eagency/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/fathom</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fathom/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fathom/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/look-listen</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/look-listen/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/look-listen/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/improving-metrics</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/improving-metrics/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/improving-metrics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/adept-marketing</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/adept-marketing/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/adept-marketing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/storm-marketing-consultants</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/storm-marketing-consultants/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/storm-marketing-consultants/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/visibility</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/visibility/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/visibility/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/brooks-bell</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/brooks-bell/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/brooks-bell/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/sell-points</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sell-points/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sell-points/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/dieproduktmacher-gmbh</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dieproduktmacher-gmbh/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dieproduktmacher-gmbh/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/iprospect-nl</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-nl/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-nl/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/ag-consult</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ag-consult/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ag-consult/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/analytics-pros</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/analytics-pros/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/analytics-pros/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/acr-analytics-llc</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/acr-analytics-llc/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/acr-analytics-llc/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/clearhead</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/clearhead/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/clearhead/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/kalio</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/kalio/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/kalio/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/wider-funnel</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/wider-funnel/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/wider-funnel/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/sitetuners</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sitetuners/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sitetuners/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/conversion-rate-experts</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-rate-experts/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-rate-experts/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/blue-acorn</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blue-acorn/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blue-acorn/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/33-sticks</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/33-sticks/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/33-sticks/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/stream20</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stream20/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stream20/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/first-new-zealand</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-new-zealand/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-new-zealand/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/big-orange-button-ab</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/big-orange-button-ab/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/big-orange-button-ab/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/first-australia</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-australia/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-australia/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/blast-analytics-and-marketing</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blast-analytics-and-marketing/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blast-analytics-and-marketing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/conversion-factory</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-factory/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-factory/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/swell-path</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/swell-path/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/swell-path/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/redeye-international-ltd</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/redeye-international-ltd/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/redeye-international-ltd/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/funnelenvy</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/funnelenvy/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/funnelenvy/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/conversionlift</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionlift/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionlift/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/iprospect-uk</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-uk/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-uk/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/vertical-nerve</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vertical-nerve/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vertical-nerve/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/stratigent</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stratigent/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stratigent/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/markitekt</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/markitekt/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/markitekt/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/uptilab</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/uptilab/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/uptilab/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/catbirdseat</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catbirdseat/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catbirdseat/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/catchi</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catchi/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catchi/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/spiralyze</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/spiralyze/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/spiralyze/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/smart-internet-media</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/smart-internet-media/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/smart-internet-media/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/vovia</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vovia/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vovia/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/bluerank-sp-zoo</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bluerank-sp-zoo/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bluerank-sp-zoo/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/elevated</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elevated/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elevated/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/deg</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/deg/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/deg/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/gexeed</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/gexeed/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/gexeed/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/prwd</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prwd/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prwd/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/fresh-egg</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fresh-egg/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fresh-egg/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/digitaslbi</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaslbi/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaslbi/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/schaetzcro</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/schaetzcro/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/schaetzcro/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/digitaloperative</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaloperative/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaloperative/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/conversionconsult</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionconsult/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionconsult/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/conversion-kings</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-kings/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-kings/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/crometrics</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/crometrics/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/crometrics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/sparkline</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sparkline/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sparkline/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/conversionista-ab</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionista-ab/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionista-ab/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/mindberry</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/mindberry/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/mindberry/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/elite-sem</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elite-sem/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elite-sem/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/growth</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/growth/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/growth/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/dp6</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dp6/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dp6/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/rocket-web</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rocket-web/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rocket-web/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/roboboogie</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/roboboogie/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/roboboogie/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/peaksandpies</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/peaksandpies/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/peaksandpies/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/rise-intractive</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rise-intractive/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rise-intractive/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/prodigal-solutions</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prodigal-solutions/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prodigal-solutions/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/bv-accel</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bv-accel/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bv-accel/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/partners/solutions/ie-agency</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ie-agency/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ie-agency/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/small-business</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/enterprises</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/benefits</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/publishers</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/ecommerce</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/resources/ab-testing-tool/</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/ab-testing-tool/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/ab-testing-tool/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/mobile</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/faq</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/gettingstarted</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/gettingstarted/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/gettingstarted/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/resources/live-demo-webinar</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.com/terms/05/30/2013</loc>
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/05/30/2013/" />
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/05/30/2013/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/about/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/statistics/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/statistics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/statistics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/statistics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/statistics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/statistics/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/statistics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/jobs/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/split-testing/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/split-testing/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/split-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/customers/customer-stories/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/resources/multivariate-testing/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-testing/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/privacy</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/pricing</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/pricing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/pricing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/pricing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/pricing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/pricing/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/pricing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/security/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/security/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/security/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/security/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/security/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/security/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/security/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/security/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/security/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/security/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/security/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/events/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/small-business/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/demo/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/demo/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/demo/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/demo/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/demo/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/demo/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/demo/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/demo/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/demo/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/demo/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/demo/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/ab-testing/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/mobile/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/privacy/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/faq/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/terms</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/resources/sample-size-calculator/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/sample-size-calculator/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/sample-size-calculator/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/press/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/resources/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/benefits/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/ecommerce/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/enterprises/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/contact/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/resources/live-demo-webinar/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/customers/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/opt_out/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/opt_out/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/opt_out/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/terms/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/publishers/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/about</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/events</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/jobs</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/resources/multivariate-test-vs-ab-test</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-test-vs-ab-test/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-test-vs-ab-test/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/press</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/contact</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/communities</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/communities/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/communities/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/communities/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/communities/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/communities/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/communities/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/communities/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/communities/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/communities/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/communities/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/ab-testing</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/resources/split-testing-tool</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/split-testing-tool/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/split-testing-tool/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/parsely</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/parsely/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/parsely/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/skymosity</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/skymosity/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/skymosity/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/qualaroo</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/qualaroo/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/qualaroo/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/sessioncam</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sessioncam/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sessioncam/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/segment</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/segment/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/segment/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/inspectlet</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/inspectlet/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/inspectlet/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/bluekai</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bluekai/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bluekai/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/tealium</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/tealium/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/tealium/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/freespee</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/freespee/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/freespee/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/episerver</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/episerver/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/episerver/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/delacon</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/delacon/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/delacon/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/google-analytics</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/google-analytics/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/google-analytics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/lotame</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lotame/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lotame/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/avanser</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/avanser/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/avanser/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/moat</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/moat/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/moat/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/ptengine</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/ptengine/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/ptengine/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/crazy-egg</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/crazy-egg/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/crazy-egg/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/dialogtech</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/dialogtech/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/dialogtech/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/demandbase</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/demandbase/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/demandbase/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/clicktale</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/clicktale/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/clicktale/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/bizible</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bizible/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bizible/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/comscore</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/comscore/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/comscore/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/signal</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/signal/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/signal/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/sitecatalyst</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sitecatalyst/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sitecatalyst/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/mixpanel</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/mixpanel/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/mixpanel/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/kissmetrics</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/kissmetrics/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/kissmetrics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/woopra</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/woopra/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/woopra/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/lytics</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lytics/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lytics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/at-internet</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/at-internet/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/at-internet/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/technology/krux</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/krux/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/krux/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/customers/customer-stories</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/customers</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/privacy/12/16/2013</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/12/16/2013/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/12/16/2013/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/nonprofits</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/nonprofits/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/nonprofits/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/resources</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/k60analytics</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/k60analytics/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/k60analytics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/divisadero</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/divisadero/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/divisadero/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/tiekinetix</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/tiekinetix/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/tiekinetix/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/eagency</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/eagency/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/eagency/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/fathom</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fathom/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fathom/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/look-listen</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/look-listen/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/look-listen/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/improving-metrics</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/improving-metrics/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/improving-metrics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/adept-marketing</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/adept-marketing/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/adept-marketing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/storm-marketing-consultants</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/storm-marketing-consultants/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/storm-marketing-consultants/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/visibility</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/visibility/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/visibility/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/brooks-bell</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/brooks-bell/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/brooks-bell/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/sell-points</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sell-points/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sell-points/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/dieproduktmacher-gmbh</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dieproduktmacher-gmbh/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dieproduktmacher-gmbh/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/iprospect-nl</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-nl/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-nl/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/ag-consult</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ag-consult/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ag-consult/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/analytics-pros</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/analytics-pros/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/analytics-pros/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/acr-analytics-llc</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/acr-analytics-llc/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/acr-analytics-llc/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/clearhead</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/clearhead/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/clearhead/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/kalio</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/kalio/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/kalio/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/wider-funnel</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/wider-funnel/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/wider-funnel/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/sitetuners</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sitetuners/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sitetuners/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/conversion-rate-experts</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-rate-experts/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-rate-experts/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/blue-acorn</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blue-acorn/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blue-acorn/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/33-sticks</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/33-sticks/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/33-sticks/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/stream20</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stream20/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stream20/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/first-new-zealand</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-new-zealand/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-new-zealand/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/big-orange-button-ab</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/big-orange-button-ab/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/big-orange-button-ab/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/first-australia</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-australia/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-australia/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/blast-analytics-and-marketing</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blast-analytics-and-marketing/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blast-analytics-and-marketing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/conversion-factory</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-factory/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-factory/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/swell-path</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/swell-path/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/swell-path/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/redeye-international-ltd</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/redeye-international-ltd/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/redeye-international-ltd/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/funnelenvy</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/funnelenvy/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/funnelenvy/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/conversionlift</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionlift/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionlift/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/iprospect-uk</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-uk/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-uk/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/vertical-nerve</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vertical-nerve/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vertical-nerve/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/stratigent</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stratigent/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stratigent/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/markitekt</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/markitekt/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/markitekt/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/uptilab</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/uptilab/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/uptilab/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/catbirdseat</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catbirdseat/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catbirdseat/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/catchi</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catchi/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catchi/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/spiralyze</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/spiralyze/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/spiralyze/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/smart-internet-media</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/smart-internet-media/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/smart-internet-media/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/vovia</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vovia/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vovia/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/bluerank-sp-zoo</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bluerank-sp-zoo/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bluerank-sp-zoo/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/elevated</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elevated/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elevated/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/deg</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/deg/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/deg/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/gexeed</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/gexeed/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/gexeed/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/prwd</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prwd/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prwd/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/fresh-egg</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fresh-egg/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fresh-egg/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/digitaslbi</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaslbi/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaslbi/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/schaetzcro</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/schaetzcro/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/schaetzcro/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/digitaloperative</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaloperative/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaloperative/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/conversionconsult</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionconsult/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionconsult/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/conversion-kings</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-kings/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-kings/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/crometrics</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/crometrics/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/crometrics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/sparkline</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sparkline/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sparkline/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/conversionista-ab</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionista-ab/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionista-ab/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/mindberry</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/mindberry/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/mindberry/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/elite-sem</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elite-sem/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elite-sem/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/growth</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/growth/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/growth/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/dp6</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dp6/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dp6/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/rocket-web</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rocket-web/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rocket-web/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/roboboogie</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/roboboogie/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/roboboogie/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/peaksandpies</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/peaksandpies/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/peaksandpies/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/rise-intractive</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rise-intractive/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rise-intractive/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/prodigal-solutions</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prodigal-solutions/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prodigal-solutions/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/bv-accel</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bv-accel/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bv-accel/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/partners/solutions/ie-agency</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ie-agency/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ie-agency/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/small-business</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/enterprises</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/benefits</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/publishers</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/ecommerce</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/resources/ab-testing-tool/</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/ab-testing-tool/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/ab-testing-tool/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/mobile</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/faq</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/gettingstarted</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/gettingstarted/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/gettingstarted/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/resources/live-demo-webinar</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.de/terms/05/30/2013</loc>
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/05/30/2013/" />
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/05/30/2013/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/about/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/statistics/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/statistics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/statistics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/statistics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/statistics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/statistics/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/statistics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/jobs/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/split-testing/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/split-testing/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/split-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/customers/customer-stories/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/resources/multivariate-testing/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-testing/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/privacy</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/pricing</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/pricing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/pricing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/pricing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/pricing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/pricing/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/pricing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/security/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/security/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/security/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/security/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/security/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/security/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/security/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/security/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/security/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/security/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/security/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/events/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/small-business/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/demo/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/demo/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/demo/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/demo/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/demo/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/demo/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/demo/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/demo/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/demo/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/demo/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/demo/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/ab-testing/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/mobile/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/privacy/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/faq/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/terms</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/resources/sample-size-calculator/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/sample-size-calculator/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/sample-size-calculator/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/press/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/resources/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/benefits/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/ecommerce/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/enterprises/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/contact/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/resources/live-demo-webinar/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/customers/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/opt_out/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/opt_out/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/opt_out/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/terms/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/publishers/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/about</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/events</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/jobs</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/resources/multivariate-test-vs-ab-test</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-test-vs-ab-test/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-test-vs-ab-test/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/press</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/contact</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/communities</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/communities/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/communities/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/communities/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/communities/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/communities/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/communities/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/communities/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/communities/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/communities/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/communities/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/ab-testing</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/resources/split-testing-tool</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/split-testing-tool/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/split-testing-tool/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/parsely</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/parsely/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/parsely/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/skymosity</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/skymosity/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/skymosity/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/qualaroo</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/qualaroo/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/qualaroo/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/sessioncam</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sessioncam/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sessioncam/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/segment</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/segment/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/segment/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/inspectlet</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/inspectlet/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/inspectlet/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/bluekai</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bluekai/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bluekai/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/tealium</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/tealium/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/tealium/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/freespee</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/freespee/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/freespee/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/episerver</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/episerver/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/episerver/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/delacon</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/delacon/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/delacon/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/google-analytics</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/google-analytics/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/google-analytics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/lotame</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lotame/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lotame/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/avanser</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/avanser/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/avanser/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/moat</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/moat/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/moat/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/ptengine</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/ptengine/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/ptengine/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/crazy-egg</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/crazy-egg/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/crazy-egg/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/dialogtech</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/dialogtech/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/dialogtech/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/demandbase</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/demandbase/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/demandbase/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/clicktale</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/clicktale/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/clicktale/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/bizible</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bizible/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bizible/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/comscore</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/comscore/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/comscore/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/signal</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/signal/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/signal/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/sitecatalyst</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sitecatalyst/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sitecatalyst/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/mixpanel</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/mixpanel/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/mixpanel/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/kissmetrics</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/kissmetrics/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/kissmetrics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/woopra</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/woopra/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/woopra/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/lytics</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lytics/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lytics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/at-internet</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/at-internet/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/at-internet/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/technology/krux</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/krux/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/krux/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/customers/customer-stories</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/customers</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/privacy/12/16/2013</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/12/16/2013/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/12/16/2013/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/nonprofits</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/nonprofits/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/nonprofits/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/resources</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/k60analytics</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/k60analytics/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/k60analytics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/divisadero</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/divisadero/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/divisadero/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/tiekinetix</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/tiekinetix/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/tiekinetix/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/eagency</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/eagency/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/eagency/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/fathom</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fathom/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fathom/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/look-listen</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/look-listen/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/look-listen/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/improving-metrics</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/improving-metrics/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/improving-metrics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/adept-marketing</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/adept-marketing/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/adept-marketing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/storm-marketing-consultants</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/storm-marketing-consultants/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/storm-marketing-consultants/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/visibility</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/visibility/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/visibility/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/brooks-bell</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/brooks-bell/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/brooks-bell/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/sell-points</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sell-points/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sell-points/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/dieproduktmacher-gmbh</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dieproduktmacher-gmbh/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dieproduktmacher-gmbh/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/iprospect-nl</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-nl/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-nl/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/ag-consult</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ag-consult/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ag-consult/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/analytics-pros</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/analytics-pros/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/analytics-pros/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/acr-analytics-llc</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/acr-analytics-llc/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/acr-analytics-llc/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/clearhead</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/clearhead/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/clearhead/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/kalio</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/kalio/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/kalio/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/wider-funnel</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/wider-funnel/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/wider-funnel/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/sitetuners</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sitetuners/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sitetuners/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/conversion-rate-experts</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-rate-experts/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-rate-experts/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/blue-acorn</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blue-acorn/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blue-acorn/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/33-sticks</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/33-sticks/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/33-sticks/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/stream20</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stream20/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stream20/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/first-new-zealand</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-new-zealand/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-new-zealand/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/big-orange-button-ab</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/big-orange-button-ab/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/big-orange-button-ab/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/first-australia</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-australia/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-australia/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/blast-analytics-and-marketing</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blast-analytics-and-marketing/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blast-analytics-and-marketing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/conversion-factory</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-factory/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-factory/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/swell-path</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/swell-path/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/swell-path/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/redeye-international-ltd</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/redeye-international-ltd/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/redeye-international-ltd/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/funnelenvy</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/funnelenvy/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/funnelenvy/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/conversionlift</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionlift/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionlift/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/iprospect-uk</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-uk/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-uk/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/vertical-nerve</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vertical-nerve/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vertical-nerve/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/stratigent</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stratigent/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stratigent/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/markitekt</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/markitekt/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/markitekt/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/uptilab</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/uptilab/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/uptilab/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/catbirdseat</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catbirdseat/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catbirdseat/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/catchi</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catchi/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catchi/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/spiralyze</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/spiralyze/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/spiralyze/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/smart-internet-media</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/smart-internet-media/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/smart-internet-media/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/vovia</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vovia/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vovia/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/bluerank-sp-zoo</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bluerank-sp-zoo/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bluerank-sp-zoo/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/elevated</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elevated/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elevated/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/deg</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/deg/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/deg/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/gexeed</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/gexeed/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/gexeed/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/prwd</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prwd/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prwd/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/fresh-egg</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fresh-egg/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fresh-egg/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/digitaslbi</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaslbi/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaslbi/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/schaetzcro</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/schaetzcro/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/schaetzcro/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/digitaloperative</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaloperative/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaloperative/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/conversionconsult</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionconsult/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionconsult/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/conversion-kings</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-kings/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-kings/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/crometrics</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/crometrics/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/crometrics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/sparkline</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sparkline/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sparkline/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/conversionista-ab</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionista-ab/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionista-ab/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/mindberry</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/mindberry/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/mindberry/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/elite-sem</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elite-sem/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elite-sem/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/growth</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/growth/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/growth/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/dp6</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dp6/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dp6/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/rocket-web</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rocket-web/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rocket-web/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/roboboogie</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/roboboogie/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/roboboogie/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/peaksandpies</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/peaksandpies/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/peaksandpies/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/rise-intractive</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rise-intractive/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rise-intractive/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/prodigal-solutions</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prodigal-solutions/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prodigal-solutions/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/bv-accel</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bv-accel/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bv-accel/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/partners/solutions/ie-agency</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ie-agency/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ie-agency/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/small-business</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/enterprises</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/benefits</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/publishers</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/ecommerce</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/resources/ab-testing-tool/</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/ab-testing-tool/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/ab-testing-tool/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/mobile</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/faq</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/gettingstarted</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/gettingstarted/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/gettingstarted/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/resources/live-demo-webinar</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.jp/terms/05/30/2013</loc>
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/05/30/2013/" />
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/05/30/2013/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/about/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/statistics/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/statistics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/statistics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/statistics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/statistics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/statistics/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/statistics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/jobs/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/split-testing/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/split-testing/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/split-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/customers/customer-stories/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/resources/multivariate-testing/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-testing/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/privacy</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/pricing</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/pricing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/pricing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/pricing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/pricing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/pricing/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/pricing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/security/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/security/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/security/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/security/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/security/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/security/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/security/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/security/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/security/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/security/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/security/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/events/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/small-business/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/demo/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/demo/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/demo/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/demo/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/demo/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/demo/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/demo/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/demo/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/demo/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/demo/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/demo/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/ab-testing/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/mobile/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/privacy/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/faq/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/terms</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/resources/sample-size-calculator/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/sample-size-calculator/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/sample-size-calculator/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/press/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/resources/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/benefits/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/ecommerce/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/enterprises/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/contact/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/resources/live-demo-webinar/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/customers/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/opt_out/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/opt_out/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/opt_out/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/terms/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/publishers/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/about</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/events</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/jobs</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/resources/multivariate-test-vs-ab-test</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-test-vs-ab-test/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-test-vs-ab-test/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/press</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/contact</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/communities</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/communities/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/communities/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/communities/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/communities/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/communities/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/communities/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/communities/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/communities/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/communities/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/communities/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/ab-testing</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/resources/split-testing-tool</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/split-testing-tool/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/split-testing-tool/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/parsely</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/parsely/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/parsely/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/skymosity</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/skymosity/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/skymosity/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/qualaroo</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/qualaroo/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/qualaroo/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/sessioncam</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sessioncam/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sessioncam/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/segment</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/segment/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/segment/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/inspectlet</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/inspectlet/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/inspectlet/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/bluekai</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bluekai/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bluekai/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/tealium</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/tealium/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/tealium/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/freespee</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/freespee/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/freespee/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/episerver</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/episerver/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/episerver/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/delacon</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/delacon/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/delacon/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/google-analytics</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/google-analytics/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/google-analytics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/lotame</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lotame/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lotame/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/avanser</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/avanser/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/avanser/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/moat</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/moat/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/moat/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/ptengine</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/ptengine/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/ptengine/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/crazy-egg</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/crazy-egg/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/crazy-egg/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/dialogtech</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/dialogtech/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/dialogtech/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/demandbase</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/demandbase/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/demandbase/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/clicktale</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/clicktale/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/clicktale/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/bizible</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bizible/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bizible/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/comscore</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/comscore/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/comscore/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/signal</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/signal/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/signal/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/sitecatalyst</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sitecatalyst/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sitecatalyst/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/mixpanel</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/mixpanel/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/mixpanel/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/kissmetrics</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/kissmetrics/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/kissmetrics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/woopra</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/woopra/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/woopra/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/lytics</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lytics/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lytics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/at-internet</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/at-internet/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/at-internet/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/technology/krux</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/krux/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/krux/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/customers/customer-stories</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/customers</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/privacy/12/16/2013</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/12/16/2013/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/12/16/2013/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/nonprofits</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/nonprofits/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/nonprofits/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/resources</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/k60analytics</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/k60analytics/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/k60analytics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/divisadero</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/divisadero/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/divisadero/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/tiekinetix</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/tiekinetix/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/tiekinetix/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/eagency</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/eagency/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/eagency/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/fathom</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fathom/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fathom/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/look-listen</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/look-listen/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/look-listen/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/improving-metrics</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/improving-metrics/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/improving-metrics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/adept-marketing</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/adept-marketing/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/adept-marketing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/storm-marketing-consultants</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/storm-marketing-consultants/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/storm-marketing-consultants/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/visibility</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/visibility/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/visibility/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/brooks-bell</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/brooks-bell/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/brooks-bell/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/sell-points</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sell-points/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sell-points/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/dieproduktmacher-gmbh</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dieproduktmacher-gmbh/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dieproduktmacher-gmbh/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/iprospect-nl</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-nl/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-nl/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/ag-consult</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ag-consult/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ag-consult/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/analytics-pros</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/analytics-pros/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/analytics-pros/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/acr-analytics-llc</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/acr-analytics-llc/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/acr-analytics-llc/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/clearhead</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/clearhead/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/clearhead/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/kalio</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/kalio/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/kalio/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/wider-funnel</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/wider-funnel/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/wider-funnel/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/sitetuners</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sitetuners/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sitetuners/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/conversion-rate-experts</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-rate-experts/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-rate-experts/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/blue-acorn</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blue-acorn/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blue-acorn/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/33-sticks</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/33-sticks/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/33-sticks/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/stream20</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stream20/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stream20/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/first-new-zealand</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-new-zealand/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-new-zealand/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/big-orange-button-ab</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/big-orange-button-ab/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/big-orange-button-ab/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/first-australia</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-australia/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-australia/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/blast-analytics-and-marketing</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blast-analytics-and-marketing/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blast-analytics-and-marketing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/conversion-factory</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-factory/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-factory/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/swell-path</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/swell-path/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/swell-path/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/redeye-international-ltd</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/redeye-international-ltd/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/redeye-international-ltd/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/funnelenvy</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/funnelenvy/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/funnelenvy/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/conversionlift</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionlift/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionlift/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/iprospect-uk</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-uk/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-uk/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/vertical-nerve</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vertical-nerve/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vertical-nerve/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/stratigent</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stratigent/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stratigent/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/markitekt</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/markitekt/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/markitekt/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/uptilab</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/uptilab/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/uptilab/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/catbirdseat</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catbirdseat/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catbirdseat/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/catchi</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catchi/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catchi/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/spiralyze</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/spiralyze/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/spiralyze/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/smart-internet-media</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/smart-internet-media/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/smart-internet-media/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/vovia</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vovia/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vovia/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/bluerank-sp-zoo</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bluerank-sp-zoo/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bluerank-sp-zoo/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/elevated</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elevated/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elevated/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/deg</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/deg/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/deg/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/gexeed</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/gexeed/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/gexeed/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/prwd</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prwd/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prwd/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/fresh-egg</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fresh-egg/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fresh-egg/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/digitaslbi</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaslbi/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaslbi/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/schaetzcro</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/schaetzcro/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/schaetzcro/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/digitaloperative</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaloperative/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaloperative/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/conversionconsult</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionconsult/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionconsult/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/conversion-kings</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-kings/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-kings/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/crometrics</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/crometrics/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/crometrics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/sparkline</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sparkline/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sparkline/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/conversionista-ab</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionista-ab/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionista-ab/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/mindberry</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/mindberry/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/mindberry/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/elite-sem</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elite-sem/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elite-sem/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/growth</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/growth/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/growth/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/dp6</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dp6/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dp6/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/rocket-web</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rocket-web/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rocket-web/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/roboboogie</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/roboboogie/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/roboboogie/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/peaksandpies</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/peaksandpies/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/peaksandpies/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/rise-intractive</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rise-intractive/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rise-intractive/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/prodigal-solutions</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prodigal-solutions/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prodigal-solutions/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/bv-accel</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bv-accel/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bv-accel/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/partners/solutions/ie-agency</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ie-agency/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ie-agency/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/small-business</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/enterprises</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/benefits</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/publishers</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/ecommerce</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/resources/ab-testing-tool/</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/ab-testing-tool/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/ab-testing-tool/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/mobile</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/faq</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/gettingstarted</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/gettingstarted/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/gettingstarted/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/resources/live-demo-webinar</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.es/terms/05/30/2013</loc>
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/05/30/2013/" />
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/05/30/2013/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/about/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/statistics/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/statistics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/statistics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/statistics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/statistics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/statistics/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/statistics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/statistics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/jobs/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/split-testing/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/split-testing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/split-testing/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/split-testing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/split-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/customers/customer-stories/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/resources/multivariate-testing/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-testing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-testing/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-testing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/privacy</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/pricing</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/pricing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/pricing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/pricing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/pricing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/pricing/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/pricing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/pricing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/security/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/security/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/security/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/security/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/security/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/security/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/security/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/security/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/security/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/security/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/security/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/events/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/small-business/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/demo/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/demo/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/demo/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/demo/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/demo/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/demo/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/demo/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/demo/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/demo/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/demo/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/demo/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/ab-testing/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/mobile/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/privacy/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/faq/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/terms</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/resources/sample-size-calculator/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/sample-size-calculator/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/sample-size-calculator/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/sample-size-calculator/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/sample-size-calculator/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/press/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/resources/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/benefits/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/ecommerce/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/enterprises/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/contact/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/resources/live-demo-webinar/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/customers/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/opt_out/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/opt_out/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/opt_out/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/opt_out/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/opt_out/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/terms/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/publishers/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/about</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/about/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/about/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/about/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/about/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/about/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/events</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/events/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/events/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/events/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/events/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/events/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/jobs</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/jobs/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/jobs/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/resources/multivariate-test-vs-ab-test</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-test-vs-ab-test/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-test-vs-ab-test/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/multivariate-test-vs-ab-test/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/multivariate-test-vs-ab-test/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/press</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/press/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/press/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/press/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/press/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/press/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/contact</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/contact/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/contact/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/contact/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/contact/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/contact/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/communities</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/communities/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/communities/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/communities/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/communities/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/communities/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/communities/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/communities/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/communities/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/communities/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/communities/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/ab-testing</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ab-testing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ab-testing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/resources/split-testing-tool</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/split-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/split-testing-tool/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/split-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/split-testing-tool/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/parsely</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/parsely/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/parsely/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/parsely/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/parsely/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/skymosity</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/skymosity/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/skymosity/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/skymosity/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/skymosity/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/qualaroo</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/qualaroo/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/qualaroo/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/qualaroo/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/qualaroo/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/sessioncam</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sessioncam/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sessioncam/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sessioncam/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sessioncam/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/segment</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/segment/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/segment/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/segment/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/segment/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/inspectlet</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/inspectlet/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/inspectlet/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/inspectlet/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/inspectlet/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/bluekai</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bluekai/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bluekai/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bluekai/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bluekai/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/tealium</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/tealium/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/tealium/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/tealium/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/tealium/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/freespee</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/freespee/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/freespee/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/freespee/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/freespee/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/episerver</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/episerver/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/episerver/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/episerver/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/episerver/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/delacon</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/delacon/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/delacon/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/delacon/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/delacon/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/google-analytics</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/google-analytics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/google-analytics/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/google-analytics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/google-analytics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/lotame</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lotame/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lotame/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lotame/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lotame/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/avanser</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/avanser/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/avanser/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/avanser/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/avanser/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/moat</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/moat/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/moat/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/moat/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/moat/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/ptengine</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/ptengine/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/ptengine/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/ptengine/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/ptengine/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/crazy-egg</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/crazy-egg/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/crazy-egg/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/crazy-egg/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/crazy-egg/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/dialogtech</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/dialogtech/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/dialogtech/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/dialogtech/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/dialogtech/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/demandbase</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/demandbase/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/demandbase/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/demandbase/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/demandbase/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/clicktale</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/clicktale/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/clicktale/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/clicktale/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/clicktale/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/bizible</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bizible/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bizible/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/bizible/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/bizible/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/comscore</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/comscore/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/comscore/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/comscore/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/comscore/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/signal</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/signal/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/signal/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/signal/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/signal/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/sitecatalyst</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sitecatalyst/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sitecatalyst/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/sitecatalyst/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/sitecatalyst/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/mixpanel</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/mixpanel/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/mixpanel/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/mixpanel/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/mixpanel/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/kissmetrics</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/kissmetrics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/kissmetrics/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/kissmetrics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/kissmetrics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/woopra</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/woopra/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/woopra/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/woopra/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/woopra/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/lytics</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lytics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lytics/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/lytics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/lytics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/at-internet</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/at-internet/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/at-internet/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/at-internet/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/at-internet/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/technology/krux</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/krux/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/krux/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/technology/krux/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/technology/krux/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/customers/customer-stories</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/customer-stories/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/customer-stories/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/customers</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/customers/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/customers/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/customers/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/customers/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/customers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/privacy/12/16/2013</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/12/16/2013/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/12/16/2013/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/privacy/12/16/2013/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/privacy/12/16/2013/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/nonprofits</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/nonprofits/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/nonprofits/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/nonprofits/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/nonprofits/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/resources</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/k60analytics</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/k60analytics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/k60analytics/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/k60analytics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/k60analytics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/divisadero</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/divisadero/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/divisadero/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/divisadero/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/divisadero/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/tiekinetix</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/tiekinetix/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/tiekinetix/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/tiekinetix/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/tiekinetix/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/eagency</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/eagency/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/eagency/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/eagency/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/eagency/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/fathom</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fathom/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fathom/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fathom/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fathom/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/look-listen</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/look-listen/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/look-listen/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/look-listen/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/look-listen/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/improving-metrics</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/improving-metrics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/improving-metrics/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/improving-metrics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/improving-metrics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/adept-marketing</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/adept-marketing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/adept-marketing/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/adept-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/adept-marketing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/storm-marketing-consultants</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/storm-marketing-consultants/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/storm-marketing-consultants/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/storm-marketing-consultants/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/storm-marketing-consultants/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/visibility</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/visibility/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/visibility/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/visibility/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/visibility/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/brooks-bell</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/brooks-bell/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/brooks-bell/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/brooks-bell/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/brooks-bell/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/sell-points</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sell-points/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sell-points/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sell-points/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sell-points/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/dieproduktmacher-gmbh</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dieproduktmacher-gmbh/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dieproduktmacher-gmbh/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dieproduktmacher-gmbh/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dieproduktmacher-gmbh/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/iprospect-nl</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-nl/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-nl/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-nl/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-nl/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/ag-consult</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ag-consult/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ag-consult/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ag-consult/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ag-consult/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/analytics-pros</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/analytics-pros/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/analytics-pros/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/analytics-pros/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/analytics-pros/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/acr-analytics-llc</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/acr-analytics-llc/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/acr-analytics-llc/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/acr-analytics-llc/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/acr-analytics-llc/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/clearhead</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/clearhead/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/clearhead/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/clearhead/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/clearhead/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/kalio</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/kalio/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/kalio/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/kalio/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/kalio/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/wider-funnel</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/wider-funnel/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/wider-funnel/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/wider-funnel/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/wider-funnel/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/sitetuners</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sitetuners/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sitetuners/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sitetuners/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sitetuners/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/conversion-rate-experts</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-rate-experts/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-rate-experts/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-rate-experts/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-rate-experts/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/blue-acorn</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blue-acorn/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blue-acorn/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blue-acorn/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blue-acorn/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/33-sticks</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/33-sticks/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/33-sticks/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/33-sticks/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/33-sticks/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/stream20</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stream20/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stream20/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stream20/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stream20/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/first-new-zealand</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-new-zealand/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-new-zealand/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-new-zealand/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-new-zealand/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/big-orange-button-ab</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/big-orange-button-ab/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/big-orange-button-ab/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/big-orange-button-ab/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/big-orange-button-ab/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/first-australia</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-australia/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-australia/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/first-australia/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/first-australia/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/blast-analytics-and-marketing</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blast-analytics-and-marketing/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blast-analytics-and-marketing/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/blast-analytics-and-marketing/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/blast-analytics-and-marketing/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/conversion-factory</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-factory/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-factory/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-factory/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-factory/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/swell-path</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/swell-path/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/swell-path/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/swell-path/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/swell-path/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/redeye-international-ltd</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/redeye-international-ltd/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/redeye-international-ltd/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/redeye-international-ltd/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/redeye-international-ltd/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/funnelenvy</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/funnelenvy/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/funnelenvy/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/funnelenvy/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/funnelenvy/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/conversionlift</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionlift/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionlift/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionlift/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionlift/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/iprospect-uk</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-uk/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-uk/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/iprospect-uk/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/iprospect-uk/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/vertical-nerve</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vertical-nerve/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vertical-nerve/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vertical-nerve/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vertical-nerve/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/stratigent</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stratigent/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stratigent/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/stratigent/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/stratigent/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/markitekt</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/markitekt/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/markitekt/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/markitekt/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/markitekt/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/uptilab</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/uptilab/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/uptilab/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/uptilab/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/uptilab/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/catbirdseat</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catbirdseat/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catbirdseat/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catbirdseat/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catbirdseat/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/catchi</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catchi/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catchi/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/catchi/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/catchi/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/spiralyze</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/spiralyze/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/spiralyze/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/spiralyze/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/spiralyze/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/smart-internet-media</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/smart-internet-media/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/smart-internet-media/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/smart-internet-media/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/smart-internet-media/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/vovia</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vovia/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vovia/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/vovia/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/vovia/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/bluerank-sp-zoo</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bluerank-sp-zoo/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bluerank-sp-zoo/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bluerank-sp-zoo/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bluerank-sp-zoo/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/elevated</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elevated/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elevated/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elevated/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elevated/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/deg</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/deg/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/deg/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/deg/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/deg/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/gexeed</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/gexeed/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/gexeed/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/gexeed/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/gexeed/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/prwd</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prwd/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prwd/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prwd/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prwd/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/fresh-egg</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fresh-egg/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fresh-egg/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/fresh-egg/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/fresh-egg/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/digitaslbi</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaslbi/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaslbi/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaslbi/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaslbi/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/schaetzcro</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/schaetzcro/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/schaetzcro/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/schaetzcro/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/schaetzcro/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/digitaloperative</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaloperative/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaloperative/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/digitaloperative/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/digitaloperative/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/conversionconsult</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionconsult/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionconsult/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionconsult/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionconsult/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/conversion-kings</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-kings/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-kings/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversion-kings/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversion-kings/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/crometrics</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/crometrics/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/crometrics/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/crometrics/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/crometrics/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/sparkline</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sparkline/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sparkline/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/sparkline/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/sparkline/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/conversionista-ab</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionista-ab/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionista-ab/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/conversionista-ab/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/conversionista-ab/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/mindberry</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/mindberry/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/mindberry/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/mindberry/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/mindberry/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/elite-sem</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elite-sem/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elite-sem/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/elite-sem/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/elite-sem/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/growth</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/growth/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/growth/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/growth/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/growth/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/dp6</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dp6/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dp6/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/dp6/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/dp6/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/rocket-web</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rocket-web/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rocket-web/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rocket-web/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rocket-web/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/roboboogie</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/roboboogie/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/roboboogie/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/roboboogie/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/roboboogie/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/peaksandpies</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/peaksandpies/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/peaksandpies/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/peaksandpies/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/peaksandpies/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/rise-intractive</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rise-intractive/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rise-intractive/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/rise-intractive/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/rise-intractive/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/prodigal-solutions</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prodigal-solutions/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prodigal-solutions/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/prodigal-solutions/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/prodigal-solutions/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/bv-accel</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bv-accel/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bv-accel/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/bv-accel/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/bv-accel/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/partners/solutions/ie-agency</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ie-agency/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ie-agency/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/partners/solutions/ie-agency/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/partners/solutions/ie-agency/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/small-business</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/small-business/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/small-business/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/enterprises</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/enterprises/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/enterprises/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/benefits</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/benefits/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/benefits/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/publishers</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/publishers/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/publishers/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/ecommerce</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/ecommerce/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/ecommerce/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/resources/ab-testing-tool/</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/ab-testing-tool/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/ab-testing-tool/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/ab-testing-tool/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/ab-testing-tool/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/mobile</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/mobile/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/mobile/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/faq</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/faq/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/faq/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/faq/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/faq/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/faq/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/gettingstarted</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/gettingstarted/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/gettingstarted/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/gettingstarted/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/gettingstarted/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/resources/live-demo-webinar</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/resources/live-demo-webinar/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/resources/live-demo-webinar/"/>
 	</url>
 	<url>
 		<loc>https://www.optimizely.fr/terms/05/30/2013</loc>
-		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/05/30/2013/" />
-		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/05/30/2013/" />
+		<xhtml:link rel="alternate" hreflang="fr" href="https://www.optimizely.fr/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="de" href="https://www.optimizely.de/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="ja" href="https://www.optimizely.jp/terms/05/30/2013/"/>
+		<xhtml:link rel="alternate" hreflang="es" href="https://www.optimizely.es/terms/05/30/2013/"/>
 	</url>
 </urlset>


### PR DESCRIPTION
@stewsmith @ihsekat - This PR just removes white space from the sitemap.xml file.
`<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/" />` becomes `<xhtml:link rel="alternate" hreflang="en" href="https://www.optimizely.com/"/>`

File size goes from 473,528 bytes -> 469,629 bytes.