### PR TITLE
Jessie wants the social proof to be removed

### DIFF
--- a/website/free-trial/index.hbs
+++ b/website/free-trial/index.hbs
@@ -17,7 +17,7 @@ how:
   - "Choose the goals you want to track"
   - "Push live and watch ROI improve"
 TR_quote: "Optimizely removed every roadblock to landing page testing and allows us to quickly make user-driven decisions."
-social_proof: true
+social_proof: false
 page_script: free-trial.js
 body_class:
 - ppc-page


### PR DESCRIPTION
The number of experiments run is very far off reality plus we're not communicating this anywhere else on the site. Jessie asked for it to be removed. Currently we don't see this on the US website due to an experiment running on that page - but the intl sites are showing the original with this data.