### PR TITLE
Update social share text on careers page

### DIFF
--- a/website/careers/index.hbs
+++ b/website/careers/index.hbs
@@ -2,7 +2,7 @@
 layout: jobs
 TR_seo_title: "Careers - Optimizely"
 page_script: jobs.js
-og_title: "Build your career with us at Optimizely"
+og_title: "Build your career with us"
 og_description: "We're helping the world turn data into action. Honored to be voted best place to work."
 ---
 {{#if page_data.benefits}}

--- a/website/careers/index.hbs
+++ b/website/careers/index.hbs
@@ -2,6 +2,8 @@
 layout: jobs
 TR_seo_title: "Careers - Optimizely"
 page_script: jobs.js
+og_title: "Build your career with us at Optimizely"
+og_description: "We're helping the world turn data into action. Honored to be voted best place to work."
 ---
 {{#if page_data.benefits}}
 <div class="container benefits">


### PR DESCRIPTION
currently the default text for a careers page is generic. this is a great place for us to have a nicer message: we're reaching out to potential employees after all.