### PR TITLE
hide untranslated content on plans page

### DIFF
--- a/website-guts/templates/partials/faq_section.hbs
+++ b/website-guts/templates/partials/faq_section.hbs
@@ -9,7 +9,7 @@
     <p class="answer">{{{answer}}}</p>
     {{/each}}
   </div>
-  <p class="contact-text">{{contact.text}}</p>
+  <!--<p class="contact-text">{{contact.text}}</p>-->
   <div id="phone-numbers-list" class="phone-container"> 
     <p class="phone-number">
     US: <a href="tel:{{contact.us_phone_number}}">{{contact.us_phone_number}}</a><br>

--- a/website/plans/index.hbs
+++ b/website/plans/index.hbs
@@ -24,7 +24,7 @@ TR_og_description: "Get started optimizing instantly, or build a custom plan for
   <div class="container">
     <div class="page-subheader-cont">
       <h1>{{this.visible_title}}</h1>
-      <a id="contact-us-button" class="talk-button">{{cta}}</a>
+      <!--<a id="contact-us-button" class="talk-button">{{cta}}</a>-->
     </div>
   </div>
 </div>


### PR DESCRIPTION
This PR is to temporarily hide untranslated plans page content. A separate PR will be created to translate this content.