### PR TITLE
Remove extra left margin from span on /plans

### DIFF
--- a/website-guts/assets/css/components/feature-list.scss
+++ b/website-guts/assets/css/components/feature-list.scss
@@ -51,6 +51,7 @@
           width: 100%;
           &[data-tooltip] {
             text-indent: 0;
+            margin-left: 0;
             &:before {
               background: none;
               height: 0;


### PR DESCRIPTION
### Old
<img width="315" alt="screen shot 2015-07-28 at 10 09 13 am" src="https://cloud.githubusercontent.com/assets/2864449/8938007/bb7c6c3e-3510-11e5-8475-3a34ce2e06eb.png">

### New
<img width="358" alt="screen shot 2015-07-28 at 10 10 13 am" src="https://cloud.githubusercontent.com/assets/2864449/8938027/dd744fd2-3510-11e5-8b5f-fa91f0895ecb.png">
